### PR TITLE
Machine storage initialization

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -9,6 +9,7 @@
     "no-inline-assembly": "off",
     "avoid-low-level-calls": "off",
     "func-visibility": ["warn", {"ignoreConstructors":true}],
-    "reason-string": "off"
+    "reason-string": "off",
+    "no-empty-blocks": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Currently in development. Done or in progress are:
 - ✅ CI build and test with Github Actions
 - ✅ High level architecture documentation
 - ✅ API documentation
-- 👉 Machine operation tests (multi-step operation of machine examples)
+- ✅ Initialization and access of machine-specific storage slots
+- ✅ Example machine tests (multi-step operation of machine examples)
 - 👉 Explore minimal clones for cheap deployments
 - 👉 Javascript NPM package for interacting with Fismo
 - 👉 "How to create and run FSMs on Fismo" doc

--- a/contracts/domain/FismoConstants.sol
+++ b/contracts/domain/FismoConstants.sol
@@ -25,6 +25,8 @@ contract FismoConstants {
     string internal constant INVALID_ACTION_ID = "Invalid action id";
     string internal constant INVALID_TARGET_ID = "Invalid target state id";
 
+    string internal constant CODELESS_INITIALIZER = "Initializer address not a contract";
+    string internal constant INITIALIZER_REVERTED = "Initializer function reverted";
     string internal constant CODELESS_GUARD = "Guard address not a contract";
     string internal constant GUARD_REVERTED = "Guard function reverted";
 

--- a/contracts/interfaces/IFismoUpdate.sol
+++ b/contracts/interfaces/IFismoUpdate.sol
@@ -28,7 +28,7 @@ interface IFismoUpdate {
     event TransitionAdded(bytes4 indexed machineId, bytes4 indexed stateId, string action, string targetStateName);
 
     /**
-     * @notice Add a new Machine to Fismo.
+     * @notice Install a Fismo Machine that requires no initialization.
      *
      * Emits:
      * - MachineAdded
@@ -41,9 +41,35 @@ interface IFismoUpdate {
      * - Machine id is not valid for Machine name
      * - Machine already exists
      *
-     * @param _machine - the machine definition to add
+     * @param _machine - the machine definition to install
      */
-    function addMachine(FismoTypes.Machine memory _machine)
+    function installMachine(FismoTypes.Machine memory _machine)
+    external;
+
+    /**
+     * @notice Install a Fismo Machine and initialize it.
+     *
+     * Emits:
+     * - MachineAdded
+     * - StateAdded
+     * - TransitionAdded
+     *
+     * Reverts if:
+     * - Caller is not contract owner
+     * - Operator address is zero
+     * - Machine id is not valid for Machine name
+     * - Machine already exists
+     * - Initializer call reverts
+     *
+     * @param _machine - the machine definition to install
+     * @param _initializer - the address of the initializer contract
+     * @param _calldata - the encoded function and args to pass in delegatecall
+     */
+    function installAndInitializeMachine(
+        FismoTypes.Machine memory _machine,
+        address _initializer,
+        bytes memory _calldata
+    )
     external;
 
     /**

--- a/contracts/lab/LockableDoor/LockableDoorGuards.sol
+++ b/contracts/lab/LockableDoor/LockableDoorGuards.sol
@@ -2,12 +2,58 @@
 pragma solidity ^0.8.0;
 
 /**
+ * @notice KeyToken is the Fismo ERC-20, which we only check for a balance of
+ */
+interface KeyToken {
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/**
  * @notice Transition guard functions
  *
  * - Machine: LockableDoor
  * - Guards: Locked/Exit
  */
 contract LockableDoorGuards {
+
+    // -------------------------------------------------------------------------
+    // MACHINE STORAGE
+    // -------------------------------------------------------------------------
+
+    // Unique storage slot id
+    bytes32 internal constant LOCKABLE_DOOR_SLOT = keccak256("LockableDoor.Storage");
+
+    // Storage slot structure
+    struct LockableDoorSlot {
+
+        // Address of the key contract
+        KeyToken keyToken;
+
+    }
+
+    // Getter for the storage slot
+    function lockableDoorSlot() internal pure returns (LockableDoorSlot storage lds) {
+        bytes32 position = LOCKABLE_DOOR_SLOT;
+        assembly {
+            lds.slot := position
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MACHINE INITIALIZER
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Machine Initializer
+     *
+     * @param _keyToken - The token contract where a non-zero balance represents a key
+     */
+    function initialize(address _keyToken)
+    external
+    {
+        // Initialize market config params
+        lockableDoorSlot().keyToken = KeyToken(_keyToken);
+    }
 
     // -------------------------------------------------------------------------
     // TRANSITION GUARDS
@@ -21,7 +67,7 @@ contract LockableDoorGuards {
     returns(string memory)
     {
         // User must have key to unlock door
-        bool hasKey = true; // TODO: check if user holds NFT representing key
+        bool hasKey = lockableDoorSlot().keyToken.balanceOf(_user) > 0;
         require(hasKey, "User must hold key to unlock.");
 
         // Success response message

--- a/docs/api/IFismoUpdate.md
+++ b/docs/api/IFismoUpdate.md
@@ -105,8 +105,8 @@ View Details
 
 ## Functions
 
-### addMachine
-Add a new Machine to Fismo.
+### installMachine
+Install a Fismo Machine that requires no initialization.
 
 <details>
 <summary>
@@ -126,7 +126,7 @@ View Details
 
 **Signature**
 ```solidity
-function addMachine(FismoTypes.Machine memory _machine)
+function installMachine(FismoTypes.Machine memory _machine)
 external;
 ```
 
@@ -135,6 +135,45 @@ external;
 | Name     | Description                    | Type     |
 | ---------- |--------------------------------|----------|
 | _machine | the machine definition to add  | FismoTypes.Machine  | 
+</details>
+
+### installAndInitializeMachine
+Install a Fismo Machine and initialize it.
+
+<details>
+<summary>
+View Details
+</summary>
+
+**Emits**
+- [`MachineAdded`](#machineadded)
+- [`StateAdded`](#stateadded)
+- [`TransitionAdded`](#transitionadded)
+
+**Reverts if**
+- Caller is not contract owner
+- Operator address is zero
+- Machine id is not valid for Machine name
+- Machine already exists
+- Initializer call reverts
+
+**Signature**
+```solidity
+function installAndInitializeMachine(
+    FismoTypes.Machine memory _machine,
+    address _initializer,
+    bytes memory _calldata
+)
+external;
+```
+
+**Arguments**
+
+| Name    | Description                       | Type  |
+| --------- |-----------------------------------|-------|
+| _machine | the machine definition to install | FismoTypes.Machine | 
+| _initializer | the address of the initializer contract | address | 
+| _calldata | the encoded function and args to pass in delegatecall | bytes | 
 </details>
 
 ### addState

--- a/scripts/config/lab-examples.js
+++ b/scripts/config/lab-examples.js
@@ -1,5 +1,9 @@
 const { nameToId } =  require('../util/name-utils');
 
+//--------------------------------------------------
+// Define Machines
+//--------------------------------------------------
+
 const NightClubMachine = {
   "operator": null,
   "name": "NightClub",
@@ -261,6 +265,12 @@ const LockableDoorMachine = {
   ]
 };
 
+
+
+//--------------------------------------------------
+// Export example descriptors
+//--------------------------------------------------
+
 exports.NightClub = {
     machine: NightClubMachine,
     operator: "NightClubOperator",
@@ -290,6 +300,10 @@ exports.StopWatch = {
 exports.LockableDoor = {
   machine: LockableDoorMachine,
   operator: "LockableDoorOperator",
+  initializer: {
+    contractName: "LockableDoorGuards",
+    signature: "initialize(address)"
+  },
   guards: [
     {
       states: ["Locked"],
@@ -298,3 +312,4 @@ exports.LockableDoor = {
     },
   ]
 };
+

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -5,6 +5,9 @@
  */
 exports.RevertReasons = {
 
+    // --------------------------------------------------------
+    // FISMO
+    // --------------------------------------------------------
     ONLY_OWNER: "Only owner may call",
     ONLY_OPERATOR: "Only operator may call",
 
@@ -21,6 +24,16 @@ exports.RevertReasons = {
     INVALID_ACTION_ID: "Invalid action id",
     INVALID_TARGET_ID: "Invalid target state id",
 
-    GUARD_REVERTED: "Guard function reverted"
+    CODELESS_INITIALIZER: "Initializer address not a contract",
+    INITIALIZER_REVERTED: "Initializer function reverted",
+
+    CODELESS_GUARD: "Guard address not a contract",
+    GUARD_REVERTED: "Guard function reverted",
+
+    // --------------------------------------------------------
+    // LOCKABLE DOOR EXAMPLE
+    // --------------------------------------------------------
+    USER_MUST_HAVE_KEY: "User must hold key to unlock."
+
 
 };

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -4,8 +4,10 @@
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 exports.InterfaceIds = {
-    IFismoOperate:       "0xcad6b576",
-    IFismoUpdate:        "0xe29cbd4a",
-    IFismoView:          "0x26276912",
-    IERC165:             "0x01ffc9a7",
+    IFismoOperate:  "0xcad6b576",
+    IFismoUpdate:   "0xf8ebd091",
+    IFismoView:     "0x26276912",
+    IERC165:        "0x01ffc9a7",
+
+    IInvalidRandom: "0xdeadfeed",  // for negative test
 };

--- a/scripts/deploy/deploy-example.js
+++ b/scripts/deploy/deploy-example.js
@@ -1,6 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const Machine = require("../../scripts/domain/Machine");
+const { deployTokens } = require('./deploy-tokens');
 const { deployTransitionGuards } = require('./deploy-guards');
 
 /**
@@ -48,17 +49,80 @@ async function deployExample(owner, fismoAddress, example, gasLimit) {
             })
         }
 
-        // Add the machine
-        await fismo.addMachine(machine.toObject());
+        // If there is an initializer defined, deploy
+        let tokens = [];
+        if (example.initializer) {
+
+            // Deploy the example tokens; example initializers will need one or more of them
+            tokens = await deployTokens(gasLimit);
+
+            // Get example-specific initialization args (initializer contract and calldata)
+            const initArgs = prepareInitializerArgs(example, guards, tokens);
+
+            // Install and initialize ethe machine
+            await fismo.installAndInitializeMachine(machine.toObject(), ...initArgs);
+
+        } else {
+
+            // Just install the machine
+            await fismo.installMachine(machine.toObject());
+
+        }
 
         // Return the operator, the guards, and the guarded machine entity
-        return [operator, operatorArgs, guards, machine.clone()];
+        return [operator, operatorArgs, guards, machine.clone(), tokens];
 
     } else {
 
         throw("Invalid machine definition.");
 
     }
+
+}
+
+/**
+ * Prepare initializer arguments
+ *
+ * Only used by deployExample when an example
+ * has an initializer.
+ *
+ * Initializers vary by example, depending upon the
+ * arguments they need, so custom code is required to
+ * prepare the initializer arguments (address and calldata).
+ *
+ * By convention, the initialize functions are expected to
+ * be on the first of a machine's guard contracts rather
+ * than a separate contract, for simplicity in deployment
+ * configuration.
+ *
+ * @param example
+ * @param guards
+ * @param tokens
+ * @returns {*[]}
+ */
+function prepareInitializerArgs(example, guards, tokens) {
+
+    let initFunction, initInterface, initCallData, initializer;
+    let [fismo20, fismo721, fismo1155] = tokens;
+
+    switch (example.machine.name) {
+
+        case "LockableDoor":
+
+            // Get the initializer contract
+            initializer = guards[0].contract.address;
+
+            // Prepare the calldata
+            initFunction = "initialize(address payable)";
+            initInterface = new ethers.utils.Interface([`function ${initFunction}`]);
+            initCallData = initInterface.encodeFunctionData("initialize", [fismo20.address]);
+            break;
+
+        default:
+            break;
+    }
+
+    return [initializer, initCallData];
 
 }
 

--- a/scripts/deploy/deploy-tokens.js
+++ b/scripts/deploy/deploy-tokens.js
@@ -14,7 +14,7 @@ const ethers = hre.ethers;
  */
 async function deployTokens(gasLimit) {
 
-    const deployedTokens = [], tokens = ["Fismo20", "Fismo721", "Fismo1155"]
+    const deployedTokens = [], tokens = ["Fismo20", "Fismo721", "Fismo1155"];
 
     // Deploy all the tokens
     while (tokens.length) {


### PR DESCRIPTION
### Support for machine-specific storage and initialization

* This fixes #2 

* In .solhint.json,
  - turned off no-empty-blocks

* In deploy-example.js,
  - import deploy-tokens
  - in deployExample()
    - if example has an initializer configured,
      - deploy the tokens
      - get the initializer arguments
      - install and initialize the machine
  - added prepareInitializerArgs()
    - returns the initializer contract address and the encoded calldata
* In deploy-tokens.js,
  - added semi-colon line ending

* In FismoConstants.sol,
  - added revert reasons
    - CODELESS_INITIALIZER
    - INITIALIZER_REVERTED

* In FismoTest.js,
  - Removed unused StopWatch import
  - refactor / renamed addMachine to installMachine
  - added tests
    - "Should not indicate support for a random interface"
    - "Should accept a valid guarded State with guard logic"
    - "Should revert if guard logic address is not a contract"

* In FismoUpdate.sol, IFismoUpdate.sol, and IFismoUpdate.md
  - refactor/renamed addMachine to installMachine
  - added installAndInitializeMachine

* In FismoUpdate.sol,
  - refactor/extracted functionality from installMachine into internal addMachine method

* In lab-examples.js,
  - added initializer block to LockableDoor example

* In LockableDoorGuards.sol,
  - added KeyToken interface
    - has balanceOf signature ala ERC20/721
  - define the LockableDoorSlot struct and associated storage slot getter
  - added initialize method
    - takes an address and stores as keyToken in the machine's storage slot
  - in LockableDoor_Locked_Exit method,
    - replaced hasKey's hardcoded true assignment with a check that the user has a non-zero balance on the keyToken contract

* In LockableDoorTest.js,
  - In test "Should invoke action 'Unlock' from state 'Locked' if user has key"
    - issued the user a key token before attempting to unlock the door
  - Added test
    - "Should revert if user doesn't have key for action 'Unlock'"
      - same as positive test, just doesn't issue a key token to the user before attempting to unlock the door

* Updated README.md

* In revert-reasons.js,
  - added missing revert reasons

* In supported-interfaces.js,
  - updated IFismoUpdate interface id
  - added IInvalidRandom interface id