### PR TITLE
Cheap cloning (completed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,31 @@
 ## Finite State Machines for Ethereum
 #### An experiment in [Deterministic Proxy](docs/about.md#a-deterministic-proxy-experiment) design
 
-## Status
-[![Node.js CI](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml/badge.svg)](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml)
+## Status  🔬 [![Node.js CI](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml/badge.svg)](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml) 🔬 ![85%](https://progress-bar.dev/85/?title=Progress&width=120&color=000000)
+
+
 
 Currently in development. Done or in progress are:
-- ✅ Developer setup and tasks documentation
-- ✅ Developer environment configuration template
 - ✅ Working Deterministic Proxy implementation
-- ✅ Deployable examples
-- ✅ Clear and complete inline [NatSpec](https://docs.soliditylang.org/en/v0.8.11/natspec-format.html?highlight=NatSpec) docs and in-method comments
+- ✅ Working Finite State Machine protocol
+- ✅ Minimal clones for cheap deployments ($40 vs $2000)!!!
+- ✅ Initialization and access of machine-specific storage slots
+- ✅ Clear and complete interface documentation and inline code comments
 - ✅ Separation of concerns into inheritance tree for easy comprehension and maintenance
 - ✅ Shared domain model for contract structures, enums, events, & constants
-- ✅ Domain model expressed in JS
+- ✅ Domain model expressed in JS for use in deployment and testing
 - ✅ Domain model unit tests
-- ✅ Script modules for reuse in both deployment and testing
+- ✅ Shared Script modules for reuse in both deployment and testing
 - ✅ Contract unit tests
-- ✅ CI build and test with Github Actions
-- ✅ High level architecture documentation
-- ✅ API documentation
-- ✅ Initialization and access of machine-specific storage slots
+- ✅ Working examples
 - ✅ Example machine tests (multi-step operation of machine examples)
-- 👉 Explore minimal clones for cheap deployments
-- 👉 Javascript NPM package for interacting with Fismo
-- 👉 "How to create and run FSMs on Fismo" doc
+- ✅ CI build and test with Github Actions
+- ✅ Contract interfaces documentation
+- ✅ Developer setup and tasks documentation
+- ✅ Developer environment configuration template
+- ✅ High level architecture documentation
+- 👉 Complete code coverage
+- 👉 Create NPM package
+- 👉 Write "How to create, install and operate machines on Fismo" doc
 
   [![Created by Futurescale](docs/images/created-by.png)](https://futurescale.com)

--- a/contracts/Fismo.sol
+++ b/contracts/Fismo.sol
@@ -2,22 +2,24 @@
 pragma solidity ^0.8.0;
 
 import { FismoOperate } from  "./components/FismoOperate.sol";
+import { FismoClone } from  "./components/FismoClone.sol";
 
 /**
  * @title Fismo - Finite State Machines with a twist
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
-contract Fismo is FismoOperate  {
+contract Fismo is FismoClone, FismoOperate {
 
     /**
-     * Constructor
+     * @notice Constructor
      *
-     * Sets the initial contract owner
-     *
-     * @param _owner the address of the contract owner
+     * Note:
+     * - Only executed by an original Fismo deployment
+     * - Clones have their init() method called to do same
      */
-    constructor(address _owner) payable {
-        setOwner( _owner);
+    constructor() payable {
+        setOwner(msg.sender);
+        setIsFismo(true);
     }
 
 }

--- a/contracts/components/FismoAccess.sol
+++ b/contracts/components/FismoAccess.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { FismoView } from "./FismoView.sol";
-import { FismoStore } from "./FismoStore.sol";
+import { FismoStore } from "../domain/FismoStore.sol";
 
 /**
  * @title FismoControl

--- a/contracts/components/FismoClone.sol
+++ b/contracts/components/FismoClone.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.0;
+
+import { FismoUpdate } from "./FismoUpdate.sol";
+import { FismoStore } from "../domain/FismoStore.sol";
+import { IFismoClone } from "../interfaces/IFismoClone.sol";
+
+/**
+ * @title FismoClone
+ *
+ * Create and initialize a Fismo clone
+ *
+ * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
+ */
+contract FismoClone is IFismoClone, FismoUpdate  {
+
+    /**
+     * @notice Initialize a cloned Fismo instance.
+     *
+     * Reverts if:
+     * - Owner is not zero address
+     *
+     * Note:
+     * - Must be external to be called from the Fismo factory.
+     *
+     * @param _owner - the owner of the cloned Fismo instance
+     */
+    function init(address _owner)
+    external
+    override
+    {
+        address owner = FismoStore.getStore().owner;
+        require(owner == address(0), INVALID_ADDRESS);
+        setOwner(_owner);
+        setIsFismo(false);
+    }
+
+
+    function cloneFismo()
+    external
+    override
+    returns (address instance)
+    {
+        // Make sure this isn't a clone
+        require(getStore().isFismo, MULTIPLICITY);
+
+        // Clone the contract
+        instance = clone();
+
+        // Initialize the clone
+        IFismoClone(instance).init(msg.sender);
+
+        // Notify watchers of state change
+        emit FismoCloned(msg.sender, instance);
+    }
+
+    /**
+     * @dev Deploys and returns the address of a Fismo clone
+     *
+     * Note:
+     * - This function uses the create opcode, which should never revert.
+     *
+     * @return instance - the address of the Fismo clone
+     */
+    function clone()
+    internal
+    returns (address instance) {
+
+        // Clone this contract
+        address implementation = address(this);
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create(0, ptr, 0x37)
+        }
+        require(instance != address(0), "ERC1167: create failed");
+    }
+
+}

--- a/contracts/components/FismoOperate.sol
+++ b/contracts/components/FismoOperate.sol
@@ -16,19 +16,24 @@ contract FismoOperate is IFismoOperate, FismoUpdate  {
     /**
      * Invoke an action on a configured Machine.
      *
-     * Reverts if
+     * Emits:
+     * - UserTransitioned
+     *
+     * Reverts if:
      * - Caller is not the machine's operator
      * - Machine does not exist
      * - Action is not valid for the user's current State in the given Machine
      * - any invoked Guard logic reverts
      *
-     * Emits Transitioned event if successful.
-     *
      * @param _user - the address of the user
      * @param _machineId - the id of the target machine
      * @param _actionId - the id of the action to invoke
      */
-    function invokeAction(address _user, bytes4 _machineId, bytes4 _actionId)
+    function invokeAction(
+        address _user,
+        bytes4 _machineId,
+        bytes4 _actionId
+    )
     external
     override
     onlyOperator(_machineId)
@@ -86,14 +91,14 @@ contract FismoOperate is IFismoOperate, FismoUpdate  {
         setUserState(_user, _machineId, nextState.id);
 
         // Alert listeners to change of state
-        emit Transitioned(_user, _machineId, nextState.id, response);
+        emit UserTransitioned(_user, _machineId, nextState.id, response);
 
     }
 
     /**
      * @notice Make a delegatecall to the specified guard function
      *
-     * Reverts if
+     * Reverts if:
      * - guard logic implementation is not defined
      * - guard logic reverts
      * - delegatecall attempt fails for any other reason

--- a/contracts/components/FismoTools.sol
+++ b/contracts/components/FismoTools.sol
@@ -27,7 +27,7 @@ contract FismoTools is FismoTypes, FismoConstants {
      * @return guardSignature - a string representation of the function signature
      */
     function getGuardSignature(string memory _machineName, string memory _stateName, FismoTypes.Guard _guard)
-    public
+    internal
     pure
     returns (string memory guardSignature) {
         string memory guardType = (_guard == FismoTypes.Guard.Enter) ? "_Enter" : "_Exit";

--- a/contracts/components/FismoUpdate.sol
+++ b/contracts/components/FismoUpdate.sol
@@ -14,10 +14,32 @@ import { IFismoUpdate } from "../interfaces/IFismoUpdate.sol";
 contract FismoUpdate is IFismoUpdate, FismoAccess {
 
     /**
+     * @notice Transfer ownership of the Fismo instance to another address.
+     *
+     * Reverts if:
+     * - Caller is not contract owner
+     * - New owner is zero address
+     *
+     * Emits:
+     * - OwnershipTransferred
+     *
+     * @param _newOwner - the new owner's address
+     */
+    function transferOwnership(address _newOwner)
+    external
+    override
+    onlyOwner
+    {
+        require(_newOwner != address(0), INVALID_ADDRESS);
+        setOwner(_newOwner);
+        emit OwnershipTransferred(_newOwner);
+    }
+
+    /**
      * @notice Install a Fismo Machine that requires no initialization.
      *
      * Emits:
-     * - MachineAdded
+     * - MachineInstalled
      * - StateAdded
      * - TransitionAdded
      *
@@ -42,7 +64,7 @@ contract FismoUpdate is IFismoUpdate, FismoAccess {
      * @notice Install a Fismo Machine and initialize it.
      *
      * Emits:
-     * - MachineAdded
+     * - MachineInstalled
      * - StateAdded
      * - TransitionAdded
      *
@@ -238,7 +260,7 @@ contract FismoUpdate is IFismoUpdate, FismoAccess {
      * @notice Add a new Machine to Fismo.
      *
      * Emits:
-     * - MachineAdded
+     * - MachineInstalled
      * - StateAdded
      * - TransitionAdded
      *
@@ -287,7 +309,7 @@ contract FismoUpdate is IFismoUpdate, FismoAccess {
         }
 
         // Alert listeners to change of state
-        emit MachineAdded(_machine.id, _machine.name);
+        emit MachineInstalled(_machine.id, _machine.name);
 
     }
 
@@ -398,14 +420,25 @@ contract FismoUpdate is IFismoUpdate, FismoAccess {
     /**
      * @notice Set the contract owner
      *
-     * TODO: Send owner changed event
-     *
      * @param _owner - the contract owner address
      */
     function setOwner(address _owner)
     internal
     {
         getStore().owner = _owner;
+    }
+
+    /**
+     * @notice Set the isFismo flag.
+     *
+     * @dev Will the real Fismo please stand up?
+     *
+     * @param _assertion - true if this contract is an original deployment
+     */
+    function setIsFismo(bool _assertion)
+    internal
+    {
+        getStore().isFismo = _assertion;
     }
 
 }

--- a/contracts/components/FismoView.sol
+++ b/contracts/components/FismoView.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/interfaces/IERC165.sol";
 
-import { FismoStore } from "./FismoStore.sol";
 import { FismoTools } from "./FismoTools.sol";
+import { FismoStore } from "../domain/FismoStore.sol";
 import { FismoTypes } from "../domain/FismoTypes.sol";
 import { IFismoView } from "../interfaces/IFismoView.sol";
 import { IFismoUpdate } from "../interfaces/IFismoUpdate.sol";
 import { IFismoOperate } from "../interfaces/IFismoOperate.sol";
-import { console } from "hardhat/console.sol";
+import { IFismoClone } from "../interfaces/IFismoClone.sol";
 
 /**
  * @title FismoView
@@ -19,6 +19,19 @@ import { console } from "hardhat/console.sol";
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 contract FismoView is IFismoView, FismoTools {
+
+    /**
+     * @notice Get the owner of this Fismo contract
+     *
+     * @return owner - the address of the contract owner
+     */
+    function getOwner()
+    external
+    view
+    returns (address owner)
+    {
+        return getStore().owner;
+    }
 
     /**
      * @notice Get the implementation address for a given guard selector
@@ -122,7 +135,7 @@ contract FismoView is IFismoView, FismoTools {
      */
     function supportsInterface(bytes4 _interfaceId)
     external
-    pure
+    view
     override
     returns (bool)
     {
@@ -130,7 +143,8 @@ contract FismoView is IFismoView, FismoTools {
         _interfaceId == type(IERC165).interfaceId ||
         _interfaceId == type(IFismoOperate).interfaceId ||
         _interfaceId == type(IFismoUpdate).interfaceId ||
-        _interfaceId == type(IFismoView).interfaceId
+        _interfaceId == type(IFismoView).interfaceId ||
+        (_interfaceId == type(IFismoClone).interfaceId && getStore().isFismo)
         ) ;
     }
 

--- a/contracts/domain/FismoConstants.sol
+++ b/contracts/domain/FismoConstants.sol
@@ -9,6 +9,10 @@ pragma solidity ^0.8.0;
 contract FismoConstants {
 
     // Revert Reasons
+    string internal constant MULTIPLICITY = "Can't clone a clone";
+
+    string internal constant INVALID_ADDRESS = "Invalid address";
+
     string internal constant ONLY_OWNER = "Only owner may call";
     string internal constant ONLY_OPERATOR = "Only operator may call";
 

--- a/contracts/domain/FismoStore.sol
+++ b/contracts/domain/FismoStore.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.0;
 
-import { FismoTypes } from "../domain/FismoTypes.sol";
+import { FismoTypes } from "./FismoTypes.sol";
 
 /**
  * @title FismoStore
@@ -15,6 +15,9 @@ library FismoStore {
     bytes32 internal constant FISMO_SLOT = keccak256("fismo.storage.slot");
 
     struct FismoSlot {
+
+        // Is this the original Fismo contract or a clone?
+        bool isFismo;
 
         // Address of the contract owner
         address owner;

--- a/contracts/interfaces/IFismoClone.sol
+++ b/contracts/interfaces/IFismoClone.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.0;
+
+import { FismoTypes } from "../domain/FismoTypes.sol";
+
+/**
+ * @title IFismoClone
+ *
+ * Create and initialize a Fismo clone
+ * The ERC-165 identifier for this interface is 0x08a9f5ec
+ *
+ * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
+ */
+interface IFismoClone {
+
+    /// Emitted when a user clones the Fismo contract
+    event FismoCloned(
+        address indexed owner,
+        address indexed instance
+    );
+
+    /**
+     * @notice Initialize this Fismo instance.
+     *
+     * Reverts if:
+     * - Owner is not zero address
+     *
+     * Note:
+     * Must be external to be called from the Fismo factory.
+     *
+     * @param _owner - the owner of the cloned Fismo instance
+     */
+    function init(address _owner) external;
+
+
+    /**
+     * @notice Deploys and returns the address of a Fismo clone.
+     *
+     * @return instance - the address of the Fismo clone instance
+     */
+    function cloneFismo() external returns (address instance);
+
+}

--- a/contracts/interfaces/IFismoOperate.sol
+++ b/contracts/interfaces/IFismoOperate.sol
@@ -14,7 +14,12 @@ import { FismoTypes } from "../domain/FismoTypes.sol";
 interface IFismoOperate {
 
     /// Emitted when a user transitions from one State to another.
-    event Transitioned(address indexed user, bytes4 indexed machineId, bytes4 indexed newStateId, FismoTypes.ActionResponse response);
+    event UserTransitioned(
+        address indexed user,
+        bytes4 indexed machineId,
+        bytes4 indexed newStateId,
+        FismoTypes.ActionResponse response
+    );
 
     /**
      * Invoke an action on a configured Machine.
@@ -29,8 +34,14 @@ interface IFismoOperate {
      * @param _machineId - the id of the target machine
      * @param _actionId - the id of the action to invoke
      */
-    function invokeAction(address _user, bytes4 _machineId, bytes4 _actionId)
+    function invokeAction(
+        address _user,
+        bytes4 _machineId,
+        bytes4 _actionId
+    )
     external
-    returns(FismoTypes.ActionResponse memory response);
+    returns(
+        FismoTypes.ActionResponse memory response
+    );
 
 }

--- a/contracts/interfaces/IFismoUpdate.sol
+++ b/contracts/interfaces/IFismoUpdate.sol
@@ -7,31 +7,68 @@ import { FismoTypes } from "../domain/FismoTypes.sol";
  * @title IFismoUpdate
  *
  * Interface for Fismo update functions
- * The ERC-165 identifier for this interface is 0xe29cbd4a
+ * The ERC-165 identifier for this interface is 0x0a16331a
  *
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 interface IFismoUpdate {
 
-    /// Emitted when a new Machine is added to Fismo.
-    event MachineAdded(bytes4 indexed machineId, string machineName);
+    /// Emitted when ownership of the Fismo instance is transferred
+    event OwnershipTransferred (
+        address indexed newOwner
+    );
 
-    /// Emitted when a new State is added to Fismo.
+    /// Emitted when a new Machine is installed in this Fismo instance
+    event MachineInstalled (
+        bytes4 indexed machineId,
+        string machineName
+    );
+
+    /// Emitted when a new State is added to a Fismo Machine.
     /// May be emitted multiple times during the addition of a Machine.
-    event StateAdded(bytes4 indexed machineId, bytes4 indexed stateId, string stateName);
+    event StateAdded (
+        bytes4 indexed machineId,
+        bytes4 indexed stateId,
+        string stateName
+    );
 
     /// Emitted when an existing State is updated.
-    event StateUpdated(bytes4 indexed machineId, bytes4 indexed stateId, string stateName);
+    event StateUpdated (
+        bytes4 indexed machineId,
+        bytes4 indexed stateId,
+        string stateName
+    );
 
     /// Emitted when a new Transition is added to an existing State.
     /// May be emitted multiple times during the addition of a Machine or State.
-    event TransitionAdded(bytes4 indexed machineId, bytes4 indexed stateId, string action, string targetStateName);
+    event TransitionAdded (
+        bytes4 indexed machineId,
+        bytes4 indexed stateId,
+        string action, string targetStateName
+    );
+
+    /**
+     * @notice Transfer ownership of the Fismo instance to another address.
+     *
+     * Reverts if:
+     * - Caller is not contract owner
+     * - New owner is zero address
+     *
+     * Emits:
+     * - OwnershipTransferred
+     *
+     * @param _newOwner - the new owner's address
+     */
+    function transferOwnership (
+        address _newOwner
+    )
+    external;
 
     /**
      * @notice Install a Fismo Machine that requires no initialization.
      *
      * Emits:
-     * - MachineAdded
+     * - MachineInstalled
      * - StateAdded
      * - TransitionAdded
      *
@@ -43,14 +80,16 @@ interface IFismoUpdate {
      *
      * @param _machine - the machine definition to install
      */
-    function installMachine(FismoTypes.Machine memory _machine)
+    function installMachine (
+        FismoTypes.Machine memory _machine
+    )
     external;
 
     /**
      * @notice Install a Fismo Machine and initialize it.
      *
      * Emits:
-     * - MachineAdded
+     * - MachineInstalled
      * - StateAdded
      * - TransitionAdded
      *
@@ -65,7 +104,7 @@ interface IFismoUpdate {
      * @param _initializer - the address of the initializer contract
      * @param _calldata - the encoded function and args to pass in delegatecall
      */
-    function installAndInitializeMachine(
+    function installAndInitializeMachine (
         FismoTypes.Machine memory _machine,
         address _initializer,
         bytes memory _calldata
@@ -92,7 +131,10 @@ interface IFismoUpdate {
      * @param _machineId - the id of the machine
      * @param _state - the state to add to the machine
      */
-    function addState(bytes4 _machineId, FismoTypes.State memory _state)
+    function addState (
+        bytes4 _machineId,
+        FismoTypes.State memory _state
+    )
     external;
 
     /**
@@ -116,7 +158,10 @@ interface IFismoUpdate {
      * @param _machineId - the id of the machine
      * @param _state - the state to update
      */
-    function updateState(bytes4 _machineId, FismoTypes.State memory _state)
+    function updateState (
+        bytes4 _machineId,
+        FismoTypes.State memory _state
+    )
     external;
 
     /**
@@ -139,7 +184,11 @@ interface IFismoUpdate {
      * @param _stateId - the id of the state
      * @param _transition - the transition to add to the state
      */
-    function addTransition(bytes4 _machineId, bytes4 _stateId, FismoTypes.Transition memory _transition)
+    function addTransition (
+        bytes4 _machineId,
+        bytes4 _stateId,
+        FismoTypes.Transition memory _transition
+    )
     external;
 
 }

--- a/contracts/interfaces/IFismoView.sol
+++ b/contracts/interfaces/IFismoView.sol
@@ -8,11 +8,21 @@ import { FismoTypes } from "../domain/FismoTypes.sol";
  * @title IFismoView
  *
  * Interface for Fismo view functions
- * The ERC-165 identifier for this interface is 0x26276912.
+ * The ERC-165 identifier for this interface is 0xaf1a49fa
  *
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 interface IFismoView is IERC165 {
+
+    /**
+     * @notice Get the owner of this Fismo contract
+     *
+     * @return owner - the address of the contract owner
+     */
+    function getOwner()
+    external
+    view
+    returns (address owner);
 
     /**
      * @notice Get the implementation address for a given guard selector

--- a/contracts/interfaces/SupportedInterfaces.sol
+++ b/contracts/interfaces/SupportedInterfaces.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import "./IFismoClone.sol";
 import "./IFismoOperate.sol";
 import "./IFismoUpdate.sol";
 import "./IFismoView.sol";
@@ -21,6 +22,12 @@ import "./IFismoView.sol";
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 contract SupportedInterfaces {
+
+    function getIFismoClone()
+    public pure
+    returns(bytes4 id) {
+        id = type(IFismoClone).interfaceId;
+    }
 
     function getIFismoOperate()
     public pure

--- a/docs/api/IFismoClone.md
+++ b/docs/api/IFismoClone.md
@@ -1,0 +1,93 @@
+![Fismo](../images/fismo-logo.png)
+# [Status](../../README.md) 🧪 [About](../about.md) 🧪 [FAQ](../faq.md) 🧪 Docs
+
+## [Intro](../intro.md) 💥 [Setup](../setup.md) 💥 [Tasks](../tasks.md) 💥 API
+
+### IFismoClone 🔬 [IFismoOperate](IFismoOperate.md) 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 [IFismoView](IFismoView.md)
+
+## Interface [IFismoClone](../../contracts/interfaces/IFismoClone.sol)
+###  Clone the Fismo Contract
+The ERC-165 identifier for this interface is `0x08a9f5ec`
+
+## Events
+
+### FismoCloned
+Emitted when a user clones the Fismo contract.
+
+**Signature**
+```solidity
+event FismoCloned(
+    address indexed owner, 
+    address indexed instance
+);
+```
+**Parameters**
+
+| Name     | Description                  | Type                     |
+|----------|------------------------------|--------------------------|
+| owner    | the owner's wallet           | address                  | 
+| clone    | the cloned Fismo contract    | address                  |
+
+## Functions
+
+### cloneFismo
+Creates and returns the address of a Fismo clone.
+
+**Reverts if**
+* Being called on a clone 
+
+**Emits**
+* [`FismoCloned`](#fismocloned)
+
+**Note**
+* The owner of the new instance will be the caller of the `cloneFismo` method.
+* No storage data from the original contract is visible to the cloned instance.
+* The instance is actually an [ERC-1167 Minimal Proxy](https://eips.ethereum.org/EIPS/eip-1167) that delegates all of its calls to the Fismo implementation contract it is cloned from, while maintaining its own storage. 
+* The Fismo clone is orders of magnitude cheaper to deploy than the full Fismo contract and behaves exactly the same. 
+* And finally yes, you *could* try to make a clone of a clone. And it would work... ok. 
+  * Unfortunately, like Micheal Keaton in [Multiplicity](https://en.wikipedia.org/wiki/Multiplicity_(film)), you would realize a sort of fidelity loss with each successive clone in the chain. 
+  * Although the logic would operate the same and the clone would store the data, each clone would be delegating the call to the clone it came from, increasing the transaction cost with each delegation.
+  * To avoid this hidden expense for the unwary, the `cloneFismo` method reverts if attempting to clone a clone.
+
+**Signature**
+```solidity
+function cloneFismo() 
+external 
+returns (
+    address instance
+);
+```
+
+**Return Values**
+
+| Name     | Description                          | Type    |
+|----------|--------------------------------------|---------|
+| instance | the address of cloned Fismo instance | address |
+
+
+### init
+Initialize this Fismo instance.
+
+**Reverts if**
+* Owner is not zero address
+
+**Note**
+* Must be external to be called from the Fismo factory.
+* Is called immediately after cloning by `cloneFismo` and can not be called again.
+
+**Signature**
+```solidity
+function init(
+    address _owner
+) 
+external;
+```
+
+**Arguments**
+
+| Name     | Description                          | Type    |
+|----------|--------------------------------------|---------|
+| _owner | the address of cloned Fismo instance | address |
+
+
+[![Created by Futurescale](../images/created-by.png)](https://futurescale.com)

--- a/docs/api/IFismoOperate.md
+++ b/docs/api/IFismoOperate.md
@@ -3,7 +3,7 @@
 
 ## [Intro](../intro.md) 💥 [Setup](../setup.md) 💥 [Tasks](../tasks.md) 💥 API
 
-### IFismoOperate 🔬 [IFismoUpdate](IFismoUpdate.md)  🔬 [IFismoView](IFismoView.md)
+### [IFismoClone](IFismoClone.md) 🔬 IFismoOperate 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 [IFismoView](IFismoView.md)
 
 ## Interface [IFismoOperate](../../contracts/interfaces/IFismoOperate.sol)
 ###  Operate Fismo Machines
@@ -11,17 +11,17 @@ The ERC-165 identifier for this interface is `0xcad6b576`
 
 ## Events
 
-### Transitioned
+### UserTransitioned
 Emitted when a user transitions from one State to another.
-
-<details>
-<summary>
-View Details
-</summary>
 
 **Signature**
 ```solidity
-event Transitioned(address indexed user, bytes4 indexed machineId, bytes4 indexed newStateId, FismoTypes.ActionResponse response);
+event UserTransitioned (
+    address indexed user, 
+    bytes4 indexed machineId, 
+    bytes4 indexed newStateId, 
+    FismoTypes.ActionResponse response
+);
 ```
 **Parameters**
 
@@ -30,21 +30,15 @@ event Transitioned(address indexed user, bytes4 indexed machineId, bytes4 indexe
 | user        | the user's wallet address    | address  | 
 | machineId   | the machine's id             | bytes4  | 
 | actionId | the id of the action invoked | bytes4  | 
-| response | the id of the action invoked | FismoTypes.ActionResponse  | 
-</details>
+| response | the id of the action invoked | FismoTypes.ActionResponse  |
 
 ## Functions
 
 ### invokeAction
 Invoke an action on a configured Machine.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Emits**
-* [`Transitioned`](#transitioned)
+* [`UserTransitioned`](#usertransitioned)
 
 **Reverts if**
 - Caller is not the machine's Operator address
@@ -54,9 +48,15 @@ View Details
 
 **Signature**
 ```solidity
-function invokeAction(address _user, bytes4 _machineId, bytes4 _actionId)
+function invokeAction(
+    address _user, 
+    bytes4 _machineId, 
+    bytes4 _actionId
+) 
 external
-returns(FismoTypes.ActionResponse memory response);
+returns(
+    FismoTypes.ActionResponse memory response
+);
 ```
 
 **Arguments**
@@ -72,6 +72,5 @@ returns(FismoTypes.ActionResponse memory response);
 | Name        | Description                                | Type          |
 | ------------- |--------------------------------------------|-------------|
 | response | the address of the guard logic implementation contract| FismoTypes.ActionResponse |
-</details>
 
 [![Created by Futurescale](../images/created-by.png)](https://futurescale.com)

--- a/docs/api/IFismoUpdate.md
+++ b/docs/api/IFismoUpdate.md
@@ -3,48 +3,60 @@
 
 ## [Intro](../intro.md) 💥 [Setup](../setup.md) 💥 [Tasks](../tasks.md) 💥 API
 
-### [IFismoOperate](IFismoOperate.md) 🔬 IFismoUpdate 🔬 [IFismoView](IFismoView.md)
+### [IFismoClone](IFismoClone.md) 🔬 [IFismoOperate](IFismoOperate.md) 🔬 IFismoUpdate 🔬 [IFismoView](IFismoView.md)
 
 ## Interface [IFismoUpdate](../../contracts/interfaces/IFismoUpdate.sol)
 ### Update Fismo Storage
-The ERC-165 identifier for this interface is `0xe29cbd4a`
+The ERC-165 identifier for this interface is `0x0a16331a`
 
 ## Events
-### MachineAdded
-Emitted when a new Machine is added to Fismo.
 
-<details>
-<summary>
-View Details
-</summary>
+### OwnershipTransferred
+Emitted when ownership of the Fismo instance is transferred.
 
 **Signature**
 ```solidity
-event MachineAdded(bytes4 indexed machineId, string machineName);
+event OwnershipTransferred (
+    address indexed newOwner
+);
+```
+**Parameters**
+
+| Name         | Description                         | Type    |
+|--------------|-------------------------------------|---------|
+| newOwner    | the new owner of the Fismo instance | address |
+
+### MachineInstalled
+Emitted when a new Machine is installed in the Fismo instance.
+
+**Signature**
+```solidity
+event MachineInstalled (
+    bytes4 indexed machineId, 
+    string machineName
+);
 ```
 **Parameters**
 
 | Name         | Description             | Type   |
 |--------------|-------------------------|--------|
 | machineId    | the machine's id        | bytes4 | 
-| machineName | the name of the machine | string | 
-</details>
+| machineName | the name of the machine | string |
 
 ### StateAdded
-Emitted when a new State is added to Fismo. 
-
-<details>
-<summary>
-View Details
-</summary>
+Emitted when a new State is added to a Fismo Machine.
 
 **Note**
-- May be emitted multiple times during the addition of a Machine.
+* May be emitted multiple times during the installation of a Machine.
 
 **Signature**
 
 ```solidity
-event StateAdded(bytes4 indexed machineId, bytes4 indexed stateId, string stateName);
+event StateAdded (
+    bytes4 indexed machineId, 
+    bytes4 indexed stateId, 
+    string stateName
+);
 ```
 **Parameters**
 
@@ -52,21 +64,19 @@ event StateAdded(bytes4 indexed machineId, bytes4 indexed stateId, string stateN
 |-----------|-----------------------|--------|
 | machineId | the machine's id      | bytes4 | 
 | stateId   | the state's id        | bytes4 | 
-| stateName | the name of the state | string | 
-</details>
+| stateName | the name of the state | string |
 
 ### StateUpdated
 Emitted when an existing State is updated. 
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Signature**
 
 ```solidity
-event StateUpdated(bytes4 indexed machineId, bytes4 indexed stateId, string stateName);
+event StateUpdated (
+    bytes4 indexed machineId, 
+    bytes4 indexed stateId, 
+    string stateName
+);
 ```
 **Parameters**
 
@@ -74,16 +84,10 @@ event StateUpdated(bytes4 indexed machineId, bytes4 indexed stateId, string stat
 |-----------|-----------------------|--------|
 | machineId | the machine's id      | bytes4 | 
 | stateId   | the state's id        | bytes4 | 
-| stateName | the name of the state | string | 
-</details>
+| stateName | the name of the state | string |
 
 ### TransitionAdded
 Emitted when a new Transition is added to an existing State. 
-
-<details>
-<summary>
-View Details
-</summary>
 
 **Note**
 - May be emitted multiple times during the addition of a Machine or State.
@@ -91,7 +95,12 @@ View Details
 **Signature**
 
 ```solidity
-  event TransitionAdded(bytes4 indexed machineId, bytes4 indexed stateId, string action, string targetStateName);
+event TransitionAdded (
+    bytes4 indexed machineIdΩ, 
+    bytes4 indexed stateId, 
+    string action, 
+    string targetStateName
+);
 ```
 **Parameters**
 
@@ -100,21 +109,40 @@ View Details
 | machineId | the machine's id             | bytes4 | 
 | stateId   | the state's id               | bytes4 | 
 | action | the name of the action       | string | 
-| targetStateName | the name of the target state | string | 
-</details>
+| targetStateName | the name of the target state | string |
 
 ## Functions
+
+### transferOwnership
+Transfer ownership of the Fismo instance to another address.
+
+**Emits**
+- [`OwnershipTransferred`](#ownershiptransferred)
+
+**Reverts if**
+- Caller is not contract owner
+- New owner is zero address
+
+**Signature**
+```solidity
+function transferOwnership (
+    address _newOwner
+) 
+external;
+```
+
+**Arguments**
+
+| Name      | Description                    | Type    |
+|-----------|--------------------------------|---------|
+| _newOwner | the new owner's address  | address |
+
 
 ### installMachine
 Install a Fismo Machine that requires no initialization.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Emits**
-- [`MachineAdded`](#machineadded)
+- [`MachineInstalled`](#machineadded)
 - [`StateAdded`](#stateadded)
 - [`TransitionAdded`](#transitionadded)
 
@@ -126,7 +154,9 @@ View Details
 
 **Signature**
 ```solidity
-function installMachine(FismoTypes.Machine memory _machine)
+function installMachine (
+    FismoTypes.Machine memory _machine
+) 
 external;
 ```
 
@@ -134,19 +164,13 @@ external;
 
 | Name     | Description                    | Type     |
 | ---------- |--------------------------------|----------|
-| _machine | the machine definition to add  | FismoTypes.Machine  | 
-</details>
+| _machine | the machine definition to add  | FismoTypes.Machine  |
 
 ### installAndInitializeMachine
 Install a Fismo Machine and initialize it.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Emits**
-- [`MachineAdded`](#machineadded)
+- [`MachineInstalled`](#machineinstalled)
 - [`StateAdded`](#stateadded)
 - [`TransitionAdded`](#transitionadded)
 
@@ -159,11 +183,11 @@ View Details
 
 **Signature**
 ```solidity
-function installAndInitializeMachine(
+function installAndInitializeMachine (
     FismoTypes.Machine memory _machine,
     address _initializer,
     bytes memory _calldata
-)
+) 
 external;
 ```
 
@@ -173,24 +197,14 @@ external;
 | --------- |-----------------------------------|-------|
 | _machine | the machine definition to install | FismoTypes.Machine | 
 | _initializer | the address of the initializer contract | address | 
-| _calldata | the encoded function and args to pass in delegatecall | bytes | 
-</details>
+| _calldata | the encoded function and args to pass in delegatecall | bytes |
 
 ### addState
 Add a State to an existing Machine.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Emits**
 - [`StateAdded`](#stateadded)
 - [`TransitionAdded`](#transitionadded)
-
-**Note**
-- The new state will not be reachable by any action
-- Add one or more transitions to other states, targeting the new state
 
 **Reverts if**
 - Caller is not contract owner
@@ -198,9 +212,16 @@ View Details
 - Machine does not exist
 - Any contained transition is invalid
 
+**Note**
+- The new state will not be reachable by any action
+- Add one or more transitions to other states, targeting the new state
+
 **Signature**
 ```solidity
-function  addState(bytes4 _machineId, FismoTypes.State memory _state)
+function  addState (
+    bytes4 _machineId, 
+    FismoTypes.State memory _state
+) 
 external;
 ```
 
@@ -210,23 +231,14 @@ external;
 |-----------|-----------------------|--------|
 | _machineId | the id of the machine | bytes4 | 
 | _state | the State to add      | FismoTypes.State  |
-</details>
 
 ### updateState
 Update an existing State in an existing Machine.
 
-<details>
-<summary>
-View Details
-</summary>
-
-**Note**
-- State name and id cannot be changed.
-
 **Emits**
 - [`StateAdded`](#stateadded)
 - [`TransitionAdded`](#transitionadded)
-
+- 
 **Reverts if**
 - Caller is not contract owner
 - Machine does not exist
@@ -239,9 +251,15 @@ View Details
 - Removing one or more transitions
 - Changing exitGuarded, enterGuarded, guardLogic params
 
+**Note**
+* State name and id cannot be changed.
+
 **Signature**
 ```solidity
-function updateState(bytes4 _machineId, FismoTypes.State memory _state)
+function updateState (
+    bytes4 _machineId, 
+    FismoTypes.State memory _state
+) 
 external;
 ```
 
@@ -250,16 +268,10 @@ external;
 | Name      | Description           | Type   |
 |-----------|-----------------------|--------|
 | _machineId | the id of the machine | bytes4 | 
-| _state | the State to update   | FismoTypes.State  | 
-</details>
+| _state | the State to update   | FismoTypes.State  |
 
 ### addTransition
 Add a Transition to an existing State of an existing Machine.
-
-<details>
-<summary>
-View Details
-</summary>
 
 **Emits**
 * [`TransitionAdded`](#transitionadded)
@@ -276,7 +288,11 @@ View Details
 
 **Signature**
 ```solidity
-function addTransition(bytes4 _machineId, bytes4 _stateId, FismoTypes.Transition memory _transition)
+function addTransition (
+    bytes4 _machineId, 
+    bytes4 _stateId, 
+    FismoTypes.Transition memory _transition
+) 
 external;
 ```
 
@@ -285,8 +301,7 @@ external;
 | Name      | Description           | Type   |
 |-----------|-----------------------|--------|
 | _machineId | the id of the machine | bytes4 | 
-| _state | the State to update   | FismoTypes.State  | 
-</details>
+| _state | the State to update   | FismoTypes.State  |
 
 
 [![Created by Futurescale](../images/created-by.png)](https://futurescale.com)

--- a/docs/api/IFismoView.md
+++ b/docs/api/IFismoView.md
@@ -3,7 +3,7 @@
 
 ## [Intro](../intro.md) 💥 [Setup](../setup.md) 💥 [Tasks](../tasks.md) 💥 API
 
-### [IFismoOperate](IFismoOperate.md) 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 IFismoView
+### [IFismoClone](IFismoClone.md) 🔬 [IFismoOperate](IFismoOperate.md) 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 IFismoView
 
 ## Interface [IFismoView](../../contracts/interfaces/IFismoView.sol)
 ### View Fismo Storage
@@ -13,20 +13,19 @@ The ERC-165 identifier for this interface is `0x26276912`
 ### getGuardAddress
 Get the implementation address for a given Guard selector.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Reverts if**
 - Guard logic implementation is not defined
 
 **Signature**
 ```solidity
-function getGuardAddress(bytes4 _functionSelector)
-external
+function getGuardAddress (
+    bytes4 _functionSelector
+) 
+external 
 view
-returns (address guardAddress);
+returns (
+    address guardAddress
+);
 ```
 
 **Arguments**
@@ -40,22 +39,21 @@ returns (address guardAddress);
 | Name        | Description                                | Type           |
 | ------------- |--------------------------------------------|------------- |
 | guardAddress | the address of the guard logic implementation contract| address |
-</details>
 
 ### getLastPosition
 Get the last recorded position of the given user.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Signature**
 ```solidity
-function getLastPosition(address _user)
+function getLastPosition (
+    address _user
+)
 external
 view
-returns (bool success, FismoTypes.Position memory position);
+returns (
+    bool success, 
+    FismoTypes.Position memory position
+);
 ```
 
 **Arguments**
@@ -70,22 +68,21 @@ returns (bool success, FismoTypes.Position memory position);
 | ------------- |--------------------------------------------|---------------------|
 | success |  whether any history exists for the user | bool |
 | position | the last recorded position of the given user| FismoTypes.Position |
-</details>
 
 ### getPositionHistory
 Get the entire position history for a given user.
 
-<details>
-<summary>
-View Details
-</summary>
-
 **Signature**
 ```solidity
-function getPositionHistory(address _user)
+function getPositionHistory (
+    address _user
+)
 external
 view
-returns (bool success, FismoTypes.Position[] memory history);
+returns (
+    bool success, 
+    FismoTypes.Position[] memory history
+);
 ```
 
 **Arguments**
@@ -101,28 +98,26 @@ returns (bool success, FismoTypes.Position[] memory history);
 | success |  whether any history exists for the user | bool |
 | history | an array of Position structs  | FismoTypes.Position[] |
 
-</details>
-
 ### getUserState
 Get the current state for a given user in a given machine.
-
-<details>
-<summary>
-View Details
-</summary>
-
-**Note**
-- If the user has not interacted with the machine, the initial state for the machine is returned.
 
 **Reverts if**
 - Machine does not exist
 
+**Note**
+- If the user has not interacted with the machine, the initial state for the machine is returned.
+
 **Signature**
 ```solidity
-function getUserState(address _user, bytes4 _machineId)
+function getUserState (
+    address _user, 
+    bytes4 _machineId
+)
 external
 view
-returns (bytes4 currentStateId);
+returns (
+    bytes4 currentStateId
+);
 ```
 
 **Arguments**
@@ -134,11 +129,9 @@ returns (bytes4 currentStateId);
 
 **Return Values**
 
-| Name        | Type                   | Description                                    |
-| ------------- |------------------------|------------------------------------------------|
-| currentStateId | bytes4 | the user's current state in the given machine  |
-
-</details>
+| Name | Type   | Description                          |
+| ------ |--------|--------------------------------------|
+| currentStateId | bytes4 | the user's current state in the given machine |
 
 
 [![Created by Futurescale](../images/created-by.png)](https://futurescale.com)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -3,10 +3,11 @@
 
 ## [Intro](../intro.md) 💥 [Setup](../setup.md) 💥 [Tasks](../tasks.md) 💥 API
 
-### [IFismoOperate](IFismoOperate.md) 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 [IFismoView](IFismoView.md)
+### [IFismoClone](IFismoClone.md) 🔬 [IFismoOperate](IFismoOperate.md) 🔬 [IFismoUpdate](IFismoUpdate.md) 🔬 [IFismoView](IFismoView.md)
 
 ## Interfaces
-The exposed functionality of the `Fismo` contract is split into three interfaces: 
+The exposed functionality of the `Fismo` contract is split into several interfaces: 
+* [`IFismoClone`](IFismoClone.md) - Clone the Fismo contract.
 * [`IFismoOperate`](IFismoOperate.md) - Operate Fismo machines.
 * [`IFismoUpdate`](IFismoUpdate.md) - Update Fismo storage.
 * [`IFismoView`](IFismoView.md) - View Fismo storage.

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -8,6 +8,8 @@ exports.RevertReasons = {
     // --------------------------------------------------------
     // FISMO
     // --------------------------------------------------------
+    MULTIPLICITY: "Can't clone a clone",
+
     ONLY_OWNER: "Only owner may call",
     ONLY_OPERATOR: "Only operator may call",
 
@@ -18,6 +20,7 @@ exports.RevertReasons = {
     NO_SUCH_STATE: "No such state",
     NO_SUCH_ACTION: "No such action",
 
+    INVALID_ADDRESS: "Invalid address",
     INVALID_OPERATOR_ADDR: "Invalid operator address",
     INVALID_MACHINE_ID: "Invalid machine id",
     INVALID_STATE_ID: "Invalid state id",

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -4,9 +4,10 @@
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 exports.InterfaceIds = {
+    IFismoClone:    "0x08a9f5ec",
     IFismoOperate:  "0xcad6b576",
-    IFismoUpdate:   "0xf8ebd091",
-    IFismoView:     "0x26276912",
+    IFismoUpdate:   "0x0a16331a",
+    IFismoView:     "0xaf1a49fa",
     IERC165:        "0x01ffc9a7",
 
     IInvalidRandom: "0xdeadfeed",  // for negative test

--- a/scripts/deploy/deploy-and-verify-all.js
+++ b/scripts/deploy/deploy-and-verify-all.js
@@ -28,8 +28,8 @@ async function main() {
     console.log(divider);
 
     // Deploy Fismo
-    [fismo, fismoArgs] = await deployFismo(deployer.address, gasLimit);
-    deploymentComplete('Fismo', fismo.address, fismoArgs, contracts);
+    [fismo] = await deployFismo(gasLimit);
+    deploymentComplete('Fismo', fismo.address, [], contracts);
 
     // Deploy examples
     const examples = [NightClub, StopWatch, LockableDoor];

--- a/scripts/deploy/deploy-fismo.js
+++ b/scripts/deploy/deploy-fismo.js
@@ -6,23 +6,21 @@ const ethers = hre.ethers;
  *
  * Reused between deployment script and unit tests for consistency
  *
- * @param owner - the owner address
  * @param gasLimit - gasLimit for transactions
  *
  * @returns {Promise<(*|*|*)[]>}
  *
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
-async function deployFismo(owner, gasLimit) {
+async function deployFismo(gasLimit) {
 
     // Deploy Contract
-    const fismoArgs = [owner]
     const Fismo = await ethers.getContractFactory("Fismo");
-    const fismo = await Fismo.deploy(...fismoArgs, {gasLimit});
+    const fismo = await Fismo.deploy({gasLimit});
     await fismo.deployed();
 
-    // Return Fismo, its constructor args, and the guards
-    return [fismo, fismoArgs];
+    // Return Fismo
+    return [fismo];
 
 }
 

--- a/test/lab/LockableDoorTest.js
+++ b/test/lab/LockableDoorTest.js
@@ -43,7 +43,7 @@ describe("Lockable Door Machine", function() {
         user = accounts[1];
 
         // Deploy Fismo
-        [fismo] = await deployFismo(deployer.address, gasLimit);
+        [fismo] = await deployFismo(gasLimit);
 
         // Deploy Example
         example = LockableDoor;
@@ -84,7 +84,7 @@ describe("Lockable Door Machine", function() {
 
                 // Invoke the action via the Operator, checking for the event from Fismo
                 await expect(operator.connect(user).invokeAction(machine.id, actionId))
-                    .to.emit(fismo, 'Transitioned')
+                    .to.emit(fismo, 'UserTransitioned')
                     .withArgs(user.address, machine.id, stateId, actionResponseStruct);
 
                 // Validate the ActionResponse
@@ -109,7 +109,7 @@ describe("Lockable Door Machine", function() {
 
                 // Invoke the action via the Operator, checking for the event from Fismo
                 await expect(operator.connect(user).invokeAction(machine.id, actionId))
-                    .to.emit(fismo, 'Transitioned')
+                    .to.emit(fismo, 'UserTransitioned')
                     .withArgs(user.address, machine.id, stateId, actionResponseStruct);
 
                 // Validate the ActionResponse
@@ -162,7 +162,7 @@ describe("Lockable Door Machine", function() {
 
                 // Invoke the action via the Operator, checking for the event from Fismo
                 await expect(operator.connect(user).invokeAction(machine.id, actionId))
-                    .to.emit(fismo, 'Transitioned')
+                    .to.emit(fismo, 'UserTransitioned')
                     .withArgs(user.address, machine.id, stateId, actionResponseStruct);
 
                 // Validate the ActionResponse

--- a/test/unit/FismoTest.js
+++ b/test/unit/FismoTest.js
@@ -33,8 +33,9 @@ describe("Fismo", function() {
     // Common vars
     let accounts, deployer, user, operator, guardLogic, operatorArgs, guards, expected;
     let fismo, machine, machineObj, response, targetStateName, targetStateId, selector;
-    let state, transition, action, stateName, stateId, actionId, success;
+    let state, transition, action, stateName, stateId, actionId, success, support;
     let actionResponse, actionResponseStruct, position, positionStruct;
+    let implementation, instance, tx, event, owner, isFismo;
 
     beforeEach( async function () {
 
@@ -45,9 +46,6 @@ describe("Fismo", function() {
         operator = accounts[2];   // operator can be an EOA, which helps with unit testing
         guardLogic = accounts[3]; // just need a valid address for the guard logic since we won't invoke it in units
         user = accounts[4];
-
-        // Deploy Fismo
-        [fismo] = await deployFismo(deployer.address, gasLimit);
 
         // A simple, unguarded, single-state machine definition
         // The single state is the initial state, and its transitions are re-entrant
@@ -78,152 +76,184 @@ describe("Fismo", function() {
 
     });
 
-    context("📋 Supported Interfaces", async function () {
+    describe("🔬 As a standalone contract, called directly", function() {
 
-        context("👉 supportsInterface()", async function () {
+        beforeEach( async function () {
 
-            it("should indicate support for ERC-165 interface", async function () {
+            // We are testing the real Fismo
+            isFismo = true;
 
-                // See https://eips.ethereum.org/EIPS/eip-165#how-a-contract-will-publish-the-interfaces-it-implements
-                support = await fismo.supportsInterface(InterfaceIds.IERC165);
+            // Deploy Fismo contract
+            [fismo] = await deployFismo(gasLimit);
 
-                // Test
-                await expect(
-                    support,
-                    "ERC-165 interface not supported"
-                ).is.true;
+        });
 
-            });
+        context("📋 IFismoClone methods", async function () {
 
-            it("should indicate support for IFismoOperate interface", async function () {
+            context("👉 cloneFismo()", async function () {
 
-                // Current interfaceId for IFismoOperate
-                support = await fismo.supportsInterface(InterfaceIds.IFismoOperate);
+                it("Should create a clone of the Fismo contract for any caller", async function () {
 
-                // Test
-                await expect(
-                    support,
-                    "IFismoOperate interface not supported"
-                ).is.true;
+                    // Clone Fismo as random user
+                    response = await expect(fismo.connect(user).cloneFismo())
+                        .to.emit(fismo, 'FismoCloned');
 
-            });
+                });
 
-            it("should indicate support for IFismoUpdate interface", async function () {
+                it("Should emit a FismoCloned event with owner and instance addresses", async function () {
 
-                // Current interfaceId for IFismoUpdate
-                support = await fismo.supportsInterface(InterfaceIds.IFismoUpdate);
+                        // Clone Fismo as random user
+                        tx = await fismo.connect(user).cloneFismo();
+                        response = await tx.wait();
 
-                // Test
-                await expect(
-                    support,
-                    "IFismoUpdate interface not supported"
-                ).is.true;
+                        // Extract the owner and clone addresses from the event
+                        event = (response.events?.filter((x) => {return x.event === "FismoCloned"}))[0];
+                        owner = event.args.owner;
+                        clone = event.args.clone;
 
-            });
+                        // Clone address is not the original Fismo implementation
+                        expect(clone === fismo.address).to.be.false;
 
-            it("should indicate support for IFismoView interface", async function () {
+                        // Owner is caller
+                        expect(owner === user.address).to.be.true;
 
-                // Current interfaceId for IFismoView
-                support = await fismo.supportsInterface(InterfaceIds.IFismoView);
-
-                // Test
-                await expect(
-                    support,
-                    "IFismoView interface not supported"
-                ).is.true;
-
-            });
-
-            it("should not indicate support for a random interface", async function () {
-
-                // An invalid
-                support = await fismo.supportsInterface(InterfaceIds.IInvalidRandom);
-
-                // Test
-                await expect(
-                    support,
-                    "Random interface oddly supported?"
-                ).is.false;
+                    });
 
             });
 
         });
 
-    });
+        testFismo();
 
-    context("📋 IFismoOperate methods", async function () {
+    })
 
-        context("👉 invokeAction()", async function () {
+    describe("🔬 As a logic contract, called via clone proxy", function() {
 
-            beforeEach( async function () {
+        beforeEach( async function () {
 
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
+            // We are testing a Fismo clone
+            isFismo = false;
 
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
+            // Deploy Fismo
+            [implementation] = await deployFismo(gasLimit);
 
-                // Id of action to invoke
-                action = "Inhale";
-                actionId = nameToId(action);
+            // Clone Fismo
+            tx = await implementation.cloneFismo();
+            response = await tx.wait();
 
-            });
+            // Extract the address and owner from the event
+            event = (response.events?.filter((x) => {return x.event === "FismoCloned"}))[0];
+            instance = event.args.instance;
+            owner = event.args.owner;
+            expect(owner === deployer.address).to.be.true;
 
-            it("Should accept a valid invocation", async function () {
+            // Cast clone to Fismo
+            fismo = await ethers.getContractAt('Fismo', instance);
 
-                // The expected ActionResponse struct
-                // In this simple machine,the single state is re-entrant for each action
-                actionResponseStruct = [machine.name, action, stateName, stateName, "", ""];
-                stateId = nameToId(stateName);
+        });
 
-                // Invoke the action, checking for the event
-                await expect(fismo.connect(operator).invokeAction(user.address, machine.id, actionId))
-                    .to.emit(fismo, 'Transitioned')
-                    .withArgs(user.address, machine.id, stateId, actionResponseStruct);
+        context("📋 IFismoClone methods", async function () {
 
-                // Validate ActionResponse struct
-                actionResponse = new ActionResponse(...actionResponseStruct);
-                expect(actionResponse.isValid()).is.true;
+            context("👉 cloneFismo()", async function () {
 
-            });
+                context("💔 Revert Reasons", async function () {
 
-            context("💔 Revert Reasons", async function () {
+                    it("Should revert if contract is a clone", async function () {
 
-                /*
-                 * Reverts if
-                 * - caller is not the machine's operator (contract or EOA)
-                 * - _machineId does not refer to a valid machine
-                 * - _actionId is not valid for the user's current state in the given machine
-                 * - any invoked guard logic reverts (tested separately elsewhere)
-                 */
+                        // Attempt to clone, expect revert
+                        response = await expect(fismo.connect(user).cloneFismo())
+                            .to.revertedWith(RevertReasons.MULTIPLICITY);
 
-                it("Should revert if caller is not the machine's operator", async function () {
-
-                    // Attempt to invoke the action from user wallet, checking for revert
-                    await expect(fismo.connect(user).invokeAction(user.address, machine.id, actionId))
-                        .to.revertedWith(RevertReasons.ONLY_OPERATOR);
+                    });
 
                 });
 
-                it("Should revert if machine doesn't exist", async function () {
+            });
 
-                    // Invalid machine id
-                    machine.id = nameToId("not this");
+        });
 
-                    // Attempt to invoke the action from user wallet, checking for revert
-                    await expect(fismo.connect(user).invokeAction(user.address, machine.id, actionId))
-                        .to.revertedWith(RevertReasons.NO_SUCH_MACHINE);
+        testFismo();
+
+    })
+
+    // Tests to be run against Fismo and Fismo clone
+    function testFismo() {
+
+        context("📋 IFismoOperate methods", async function () {
+
+            context("👉 invokeAction()", async function () {
+
+                beforeEach( async function () {
+
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
+
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
+
+                    // Id of action to invoke
+                    action = "Inhale";
+                    actionId = nameToId(action);
 
                 });
 
-                it("Should revert if the action is invalid for the user's current state", async function () {
+                it("Should accept a valid invocation", async function () {
 
-                    // Invalid action id
-                    actionId = nameToId("not this");
+                    // The expected ActionResponse struct
+                    // In this simple machine,the single state is re-entrant for each action
+                    actionResponseStruct = [machine.name, action, stateName, stateName, "", ""];
+                    stateId = nameToId(stateName);
 
                     // Invoke the action, checking for the event
                     await expect(fismo.connect(operator).invokeAction(user.address, machine.id, actionId))
-                        .to.revertedWith(RevertReasons.NO_SUCH_ACTION);
+                        .to.emit(fismo, 'UserTransitioned')
+                        .withArgs(user.address, machine.id, stateId, actionResponseStruct);
+
+                    // Validate ActionResponse struct
+                    actionResponse = new ActionResponse(...actionResponseStruct);
+                    expect(actionResponse.isValid()).is.true;
+
+                });
+
+                context("💔 Revert Reasons", async function () {
+
+                    /*
+                     * Reverts if
+                     * - caller is not the machine's operator (contract or EOA)
+                     * - _machineId does not refer to a valid machine
+                     * - _actionId is not valid for the user's current state in the given machine
+                     * - any invoked guard logic reverts (tested separately elsewhere)
+                     */
+
+                    it("Should revert if caller is not the machine's operator", async function () {
+
+                        // Attempt to invoke the action from user wallet, checking for revert
+                        await expect(fismo.connect(user).invokeAction(user.address, machine.id, actionId))
+                            .to.revertedWith(RevertReasons.ONLY_OPERATOR);
+
+                    });
+
+                    it("Should revert if machine doesn't exist", async function () {
+
+                        // Invalid machine id
+                        machine.id = nameToId("not this");
+
+                        // Attempt to invoke the action from user wallet, checking for revert
+                        await expect(fismo.connect(user).invokeAction(user.address, machine.id, actionId))
+                            .to.revertedWith(RevertReasons.NO_SUCH_MACHINE);
+
+                    });
+
+                    it("Should revert if the action is invalid for the user's current state", async function () {
+
+                        // Invalid action id
+                        actionId = nameToId("not this");
+
+                        // Invoke the action, checking for the event
+                        await expect(fismo.connect(operator).invokeAction(user.address, machine.id, actionId))
+                            .to.revertedWith(RevertReasons.NO_SUCH_ACTION);
+
+                    });
 
                 });
 
@@ -231,412 +261,427 @@ describe("Fismo", function() {
 
         });
 
-    });
+        context("📋 IFismoUpdate methods", async function () {
 
-    context("📋 IFismoUpdate methods", async function () {
+            context("👉 transferOwnership()", async function () {
 
-        context("👉 installMachine()", async function () {
+                it("Should accept a valid non-zero address", async function () {
 
-            it("Should accept a valid unguarded Machine", async function () {
+                    // Transfer ownership, checking for the event
+                    await expect(fismo.transferOwnership(user.address))
+                        .to.emit(fismo, 'OwnershipTransferred')
+                        .withArgs(user.address);
 
-                // Create and validate a simple, unguarded, single-state machine
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
+                });
 
-                // Add the machine, checking for the event
-                await expect(fismo.installMachine(machine.toObject()))
-                    .to.emit(fismo, 'MachineAdded')
-                    .withArgs(machine.id, machine.name);
+
+                context("💔 Revert Reasons", async function () {
+
+                    it("Should revert if new owner address is zero address", async function () {
+
+                        // Attempt to transfer ownership to zero address, check for the revert
+                        await expect(fismo.transferOwnership(ethers.constants.AddressZero))
+                            .to.revertedWith(RevertReasons.INVALID_ADDRESS);
+
+                    });
+
+                    it("Should revert if caller is not owner", async function () {
+
+                        // Attempt to transfer ownership, check for the revert
+                        await expect(fismo.connect(user).transferOwnership(deployer.address))
+                            .to.revertedWith(RevertReasons.ONLY_OWNER);
+                    });
+
+
+                });
+
             });
 
-            it("Should accept a valid guarded Machine", async function () {
+            context("👉 installMachine()", async function () {
 
-                // Get simple, guarded machine example
-                machineObj = LockableDoor;
-                machine = Machine.fromObject(machineObj.machine);
-                machine.operator = operator.address;
-                expect(machine.isValid()).is.true;
-
-                // Deploy its transition guards
-                const guards = await deployTransitionGuards(machineObj, gasLimit);
-
-                // Add guard addresses to their associated states
-                for (const guard of guards) {
-                    guard.states.forEach(stateName => {
-                        let state = machine.getState(stateName);
-                        state.guardLogic = guard.contract.address
-                    })
-                }
-
-                // Add the machine, checking for the event
-                await expect(fismo.installMachine(machine.toObject()))
-                    .to.emit(fismo, 'MachineAdded')
-                    .withArgs(machine.id, machine.name);
-            });
-
-            context("💔 Revert Reasons", async function () {
-
-                it("Should revert if operator address is zero address", async function () {
+                it("Should accept a valid unguarded Machine", async function () {
 
                     // Create and validate a simple, unguarded, single-state machine
-                    // Operator cannot be zero address
-                    machineObj.operator = ethers.constants.AddressZero;
                     machine = Machine.fromObject(machineObj);
                     expect(machine.isValid()).is.true;
 
-                    // Attempt to add the machine, checking for the revert
+                    // Add the machine, checking for the event
                     await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_OPERATOR_ADDR);
+                        .to.emit(fismo, 'MachineInstalled')
+                        .withArgs(machine.id, machine.name);
                 });
 
-                it("Should revert if machine id is invalid", async function () {
+                it("Should accept a valid guarded Machine", async function () {
 
-                    // Create the machine, but then set an invalid machine id
-                    machine = Machine.fromObject(machineObj);
+                    // Get simple, guarded machine example
+                    machineObj = LockableDoor;
+                    machine = Machine.fromObject(machineObj.machine);
+                    machine.operator = operator.address;
                     expect(machine.isValid()).is.true;
-                    machine.id = nameToId("not this");
-                    expect(machine.isValid()).is.false;
 
-                    // Attempt to add the machine, checking for the revert
+                    // Deploy its transition guards
+                    const guards = await deployTransitionGuards(machineObj, gasLimit);
+
+                    // Add guard addresses to their associated states
+                    for (const guard of guards) {
+                        guard.states.forEach(stateName => {
+                            let state = machine.getState(stateName);
+                            state.guardLogic = guard.contract.address
+                        })
+                    }
+
+                    // Add the machine, checking for the event
                     await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_MACHINE_ID);
+                        .to.emit(fismo, 'MachineInstalled')
+                        .withArgs(machine.id, machine.name);
                 });
 
-                it("Should revert if machine already exists", async function () {
+                context("💔 Revert Reasons", async function () {
 
-                    // Create the machine and add it
+                    it("Should revert if operator address is zero address", async function () {
+
+                        // Create and validate a simple, unguarded, single-state machine
+                        // Operator cannot be zero address
+                        machineObj.operator = ethers.constants.AddressZero;
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+
+                        // Attempt to add the machine, checking for the revert
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_OPERATOR_ADDR);
+                    });
+
+                    it("Should revert if machine id is invalid", async function () {
+
+                        // Create the machine, but then set an invalid machine id
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+                        machine.id = nameToId("not this");
+                        expect(machine.isValid()).is.false;
+
+                        // Attempt to add the machine, checking for the revert
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_MACHINE_ID);
+                    });
+
+                    it("Should revert if machine already exists", async function () {
+
+                        // Create the machine and add it
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+                        await fismo.installMachine(machine.toObject());
+
+                        // Attempt to add the machine, again
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.MACHINE_EXISTS);
+                    });
+
+                    it("Should revert if a state id in a state is invalid", async function () {
+
+                        // Create the machine, but then set an invalid state id
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+                        machine.states[0].id = nameToId("not this");
+                        expect(machine.isValid()).is.false;
+
+                        // Attempt to add the machine, again
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_STATE_ID);
+                    });
+
+                    it("Should revert if an action id in a transition is invalid", async function () {
+
+                        // Create the machine, but then set an invalid action id
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+                        machine.states[0].transitions[0].actionId = nameToId("not this");
+                        expect(machine.isValid()).is.false;
+
+                        // Attempt to add the machine, again
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
+                    });
+
+                    it("Should revert if a target state id in a transition is invalid", async function () {
+
+                        // Create the machine, but then set an invalid action id
+                        machine = Machine.fromObject(machineObj);
+                        expect(machine.isValid()).is.true;
+                        machine.states[0].transitions[0].targetStateId = nameToId("not this");
+                        expect(machine.isValid()).is.false;
+
+                        // Attempt to add the machine, again
+                        await expect(fismo.installMachine(machine.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+                    });
+
+                });
+
+            });
+
+            context("👉 addState()", async function () {
+
+                beforeEach( async function () {
+
+                    // Create machine
                     machine = Machine.fromObject(machineObj);
                     expect(machine.isValid()).is.true;
+
+                    // Add machine to Fismo
                     await fismo.installMachine(machine.toObject());
 
-                    // Attempt to add the machine, again
-                    await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.MACHINE_EXISTS);
-                });
-
-                it("Should revert if a state id in a state is invalid", async function () {
-
-                    // Create the machine, but then set an invalid state id
-                    machine = Machine.fromObject(machineObj);
-                    expect(machine.isValid()).is.true;
-                    machine.states[0].id = nameToId("not this");
-                    expect(machine.isValid()).is.false;
-
-                    // Attempt to add the machine, again
-                    await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_STATE_ID);
-                });
-
-                it("Should revert if an action id in a transition is invalid", async function () {
-
-                    // Create the machine, but then set an invalid action id
-                    machine = Machine.fromObject(machineObj);
-                    expect(machine.isValid()).is.true;
-                    machine.states[0].transitions[0].actionId = nameToId("not this");
-                    expect(machine.isValid()).is.false;
-
-                    // Attempt to add the machine, again
-                    await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
-                });
-
-                it("Should revert if a target state id in a transition is invalid", async function () {
-
-                    // Create the machine, but then set an invalid action id
-                    machine = Machine.fromObject(machineObj);
-                    expect(machine.isValid()).is.true;
-                    machine.states[0].transitions[0].targetStateId = nameToId("not this");
-                    expect(machine.isValid()).is.false;
-
-                    // Attempt to add the machine, again
-                    await expect(fismo.installMachine(machine.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
-                });
-
-            });
-
-        });
-
-        context("👉 addState()", async function () {
-
-            beforeEach( async function () {
-
-                // Create machine
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
-
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
-
-                // Define a simple end state, no transitions
-                state = State.fromObject({
-                    "name": "Enlightenment",
-                    "enterGuarded": false,
-                    "exitGuarded": false
-                });
-                expect(state.isValid()).is.true;
-
-            });
-
-            it("Should accept a valid end State (no transitions)", async function () {
-
-                // Add the state to the existing machine, checking for the event
-                await expect(fismo.addState(machine.id, state.toObject()))
-                    .to.emit(fismo, 'StateAdded')
-                    .withArgs(machine.id, state.id, state.name);
-            });
-
-            it("Should accept a valid State with transitions", async function () {
-
-                // Simple end state, with transition
-                state = State.fromObject({
-                    "name": "Enlightenment",
-                    "enterGuarded": false,
-                    "exitGuarded": false,
-                    "transitions": [
-                        {
-                            action: "Accept",
-                            targetStateName: "Nirvana"
-                        }
-                    ]
-                });
-                expect(state.isValid()).is.true;
-
-                // Add the state to the existing machine, checking for the event
-                await expect(fismo.addState(machine.id, state.toObject()))
-                    .to.emit(fismo, 'StateAdded')
-                    .withArgs(machine.id, state.id, state.name);
-            });
-
-            it("Should accept a valid guarded State with guard logic", async function () {
-
-                // Simple guarded state
-                state = State.fromObject({
-                    "name": "Enlightenment",
-                    "enterGuarded": false,
-                    "exitGuarded": true,
-                    "guardLogic": fismo.address, // just needs a deployed contract with code
-                    "transitions": [
-                        {
-                            action: "Accept",
-                            targetStateName: "Nirvana"
-                        }
-                    ]
-                });
-                expect(state.isValid()).is.true;
-
-                // Add the state to the existing machine, checking for the event
-                await expect(fismo.addState(machine.id, state.toObject()))
-                    .to.emit(fismo, 'StateAdded')
-                    .withArgs(machine.id, state.id, state.name);
-            });
-
-            context("💔 Revert Reasons", async function () {
-
-                it("Should revert if the state id is invalid", async function () {
-
-                    // Simple end state, no transitions
+                    // Define a simple end state, no transitions
                     state = State.fromObject({
-                        "name": "Transcendence",
+                        "name": "Enlightenment",
                         "enterGuarded": false,
                         "exitGuarded": false
                     });
                     expect(state.isValid()).is.true;
 
-                    // Set state id to an invalid value
-                    state.id = nameToId("not this");
-                    expect(state.isValid()).is.false;
-
-                    // Attempt to add the state to the existing machine, checking for the revert
-                    await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_STATE_ID);
                 });
 
-                it("Should revert if an action id in a transition is invalid", async function () {
+                it("Should accept a valid end State (no transitions)", async function () {
 
-                    // Simple end state, no transitions
+                    // Add the state to the existing machine, checking for the event
+                    await expect(fismo.addState(machine.id, state.toObject()))
+                        .to.emit(fismo, 'StateAdded')
+                        .withArgs(machine.id, state.id, state.name);
+                });
+
+                it("Should accept a valid State with transitions", async function () {
+
+                    // Simple end state, with transition
                     state = State.fromObject({
-                        "name": "Transcendence",
+                        "name": "Enlightenment",
                         "enterGuarded": false,
                         "exitGuarded": false,
                         "transitions": [
                             {
-                                action: "Transcend",
-                                targetStateName: "Enlightenment"
+                                action: "Accept",
+                                targetStateName: "Nirvana"
                             }
                         ]
                     });
                     expect(state.isValid()).is.true;
 
-                    // Set action id to an invalid value
-                    state.transitions[0].actionId = nameToId("not this");
-                    expect(state.isValid()).is.false;
-
-                    // Attempt to add the state to the existing machine, checking for the revert
+                    // Add the state to the existing machine, checking for the event
                     await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
+                        .to.emit(fismo, 'StateAdded')
+                        .withArgs(machine.id, state.id, state.name);
                 });
 
-                it("Should revert if a target state id in a transition is invalid", async function () {
+                it("Should accept a valid guarded State with guard logic", async function () {
 
-                    // Simple end state, no transitions
+                    // Simple guarded state
                     state = State.fromObject({
-                        "name": "Transcendence",
-                        "enterGuarded": false,
-                        "exitGuarded": false,
-                        "transitions": [
-                            {
-                                action: "Transcend",
-                                targetStateName: "Enlightenment"
-                            }
-                        ]
-                    });
-                    expect(state.isValid()).is.true;
-
-                    // Set target state id to an invalid value
-                    state.transitions[0].targetStateId = nameToId("not this");
-                    expect(state.isValid()).is.false;
-
-                    // Attempt to add the state to the existing machine, checking for the revert
-                    await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
-                });
-
-                it("Should revert if guard logic address is not a contract", async function () {
-
-                    // Guarded state with an EOA supplied as the guard logic address
-                    state = State.fromObject({
-                        "name": "Transcendence",
+                        "name": "Enlightenment",
                         "enterGuarded": false,
                         "exitGuarded": true,
-                        "guardLogic": user.address,
+                        "guardLogic": fismo.address, // just needs a deployed contract with code
                         "transitions": [
                             {
-                                action: "Transcend",
-                                targetStateName: "Enlightenment"
+                                action: "Accept",
+                                targetStateName: "Nirvana"
                             }
                         ]
                     });
                     expect(state.isValid()).is.true;
 
-                    // Attempt to add the state to the existing machine, checking for the revert
+                    // Add the state to the existing machine, checking for the event
                     await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.CODELESS_GUARD);
+                        .to.emit(fismo, 'StateAdded')
+                        .withArgs(machine.id, state.id, state.name);
+                });
+
+                context("💔 Revert Reasons", async function () {
+
+                    it("Should revert if the state id is invalid", async function () {
+
+                        // Simple end state, no transitions
+                        state = State.fromObject({
+                            "name": "Transcendence",
+                            "enterGuarded": false,
+                            "exitGuarded": false
+                        });
+                        expect(state.isValid()).is.true;
+
+                        // Set state id to an invalid value
+                        state.id = nameToId("not this");
+                        expect(state.isValid()).is.false;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_STATE_ID);
+                    });
+
+                    it("Should revert if an action id in a transition is invalid", async function () {
+
+                        // Simple end state, no transitions
+                        state = State.fromObject({
+                            "name": "Transcendence",
+                            "enterGuarded": false,
+                            "exitGuarded": false,
+                            "transitions": [
+                                {
+                                    action: "Transcend",
+                                    targetStateName: "Enlightenment"
+                                }
+                            ]
+                        });
+                        expect(state.isValid()).is.true;
+
+                        // Set action id to an invalid value
+                        state.transitions[0].actionId = nameToId("not this");
+                        expect(state.isValid()).is.false;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
+                    });
+
+                    it("Should revert if a target state id in a transition is invalid", async function () {
+
+                        // Simple end state, no transitions
+                        state = State.fromObject({
+                            "name": "Transcendence",
+                            "enterGuarded": false,
+                            "exitGuarded": false,
+                            "transitions": [
+                                {
+                                    action: "Transcend",
+                                    targetStateName: "Enlightenment"
+                                }
+                            ]
+                        });
+                        expect(state.isValid()).is.true;
+
+                        // Set target state id to an invalid value
+                        state.transitions[0].targetStateId = nameToId("not this");
+                        expect(state.isValid()).is.false;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+                    });
+
+                    it("Should revert if guard logic address is not a contract", async function () {
+
+                        // Guarded state with an EOA supplied as the guard logic address
+                        state = State.fromObject({
+                            "name": "Transcendence",
+                            "enterGuarded": false,
+                            "exitGuarded": true,
+                            "guardLogic": user.address,
+                            "transitions": [
+                                {
+                                    action: "Transcend",
+                                    targetStateName: "Enlightenment"
+                                }
+                            ]
+                        });
+                        expect(state.isValid()).is.true;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.CODELESS_GUARD);
+                    });
+
                 });
 
             });
 
-        });
+            context("👉 updateState()", async function () {
 
-        context("👉 updateState()", async function () {
+                beforeEach( async function () {
 
-            beforeEach( async function () {
+                    // Create machine
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
 
-                // Create machine
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
 
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
+                    // Create updated state with enter and exit guards specified
+                    state = State.fromObject({
+                        "name": stateName,
+                        "enterGuarded": true,
+                        "exitGuarded": true,
+                        "guardLogic": fismo.address,  // Just has to be a contract. We're not invoking any code.
+                        "transitions": [
+                            {
+                                "action": "Inhale",
+                                "targetStateName": stateName,
+                            },
+                            {
+                                "action": "Exhale",
+                                "targetStateName": stateName,
+                            },
+                        ]
+                    });
+                    expect(state.isValid()).is.true;
 
-                // Create updated state with enter and exit guards specified
-                state = State.fromObject({
-                    "name": stateName,
-                    "enterGuarded": true,
-                    "exitGuarded": true,
-                    "guardLogic": fismo.address,  // Just has to be a contract. We're not invoking any code.
-                    "transitions": [
-                        {
-                            "action": "Inhale",
-                            "targetStateName": stateName,
-                        },
-                        {
-                            "action": "Exhale",
-                            "targetStateName": stateName,
-                        },
-                    ]
                 });
-                expect(state.isValid()).is.true;
 
-            });
+                it("Should accept an updated State", async function () {
 
-            it("Should accept an updated State", async function () {
-
-                // Update the state on the existing machine, checking for the event
-                await expect(fismo.updateState(machine.id, state.toObject()))
-                    .to.emit(fismo, 'StateUpdated')
-                    .withArgs(machine.id, state.id, state.name);
-            });
-
-            context("💔 Revert Reasons", async function () {
-
-                it("Should revert if the state id is invalid", async function () {
-
-                    // Set state id to an invalid value
-                    state.id = nameToId("not this");
-                    expect(state.isValid()).is.false;
-
-                    // Attempt to add the state to the existing machine, checking for the revert
+                    // Update the state on the existing machine, checking for the event
                     await expect(fismo.updateState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_STATE_ID);
+                        .to.emit(fismo, 'StateUpdated')
+                        .withArgs(machine.id, state.id, state.name);
                 });
 
-                it("Should revert if an action id in a transition is invalid", async function () {
+                context("💔 Revert Reasons", async function () {
 
-                    // Set action id to an invalid value
-                    state.transitions[0].actionId = nameToId("not this");
-                    expect(state.isValid()).is.false;
+                    it("Should revert if the state id is invalid", async function () {
 
-                    // Attempt to add the state to the existing machine, checking for the revert
-                    await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
-                });
+                        // Set state id to an invalid value
+                        state.id = nameToId("not this");
+                        expect(state.isValid()).is.false;
 
-                it("Should revert if a target state id in a transition is invalid", async function () {
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.updateState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_STATE_ID);
+                    });
 
-                    // Set target state id to an invalid value
-                    state.transitions[0].targetStateId = nameToId("not this");
-                    expect(state.isValid()).is.false;
+                    it("Should revert if an action id in a transition is invalid", async function () {
 
-                    // Attempt to add the state to the existing machine, checking for the revert
-                    await expect(fismo.addState(machine.id, state.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+                        // Set action id to an invalid value
+                        state.transitions[0].actionId = nameToId("not this");
+                        expect(state.isValid()).is.false;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
+                    });
+
+                    it("Should revert if a target state id in a transition is invalid", async function () {
+
+                        // Set target state id to an invalid value
+                        state.transitions[0].targetStateId = nameToId("not this");
+                        expect(state.isValid()).is.false;
+
+                        // Attempt to add the state to the existing machine, checking for the revert
+                        await expect(fismo.addState(machine.id, state.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+                    });
+
                 });
 
             });
 
-        });
+            context("👉 addTransition()", async function () {
 
-        context("👉 addTransition()", async function () {
+                beforeEach( async function () {
 
-            beforeEach( async function () {
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
 
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
 
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
-
-            });
-
-            it("Should accept a valid Transition", async function () {
-
-                // Create a new transition instance
-                transition = Transition.fromObject({
-                    action: "Transcend",
-                    targetStateName: "Enlightenment"
                 });
-                expect(transition.isValid()).is.true;
 
-                // Add the transition to the only state of the machine
-                await expect(fismo.addTransition(machine.id, stateId, transition.toObject()))
-                    .to.emit(fismo, 'TransitionAdded')
-                    .withArgs(machine.id, stateId, transition.action, transition.targetStateName);
-            });
-
-            context("💔 Revert Reasons", async function () {
-
-                it("Should revert if the action id is invalid", async function () {
+                it("Should accept a valid Transition", async function () {
 
                     // Create a new transition instance
                     transition = Transition.fromObject({
@@ -645,30 +690,49 @@ describe("Fismo", function() {
                     });
                     expect(transition.isValid()).is.true;
 
-                    // Set an invalid action id
-                    transition.actionId = nameToId("not this");
-
                     // Add the transition to the only state of the machine
                     await expect(fismo.addTransition(machine.id, stateId, transition.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
-
+                        .to.emit(fismo, 'TransitionAdded')
+                        .withArgs(machine.id, stateId, transition.action, transition.targetStateName);
                 });
 
-                it("Should revert if the target state id is invalid", async function () {
+                context("💔 Revert Reasons", async function () {
 
-                    // Create a new transition instance
-                    transition = Transition.fromObject({
-                        action: "Transcend",
-                        targetStateName: "Enlightenment"
+                    it("Should revert if the action id is invalid", async function () {
+
+                        // Create a new transition instance
+                        transition = Transition.fromObject({
+                            action: "Transcend",
+                            targetStateName: "Enlightenment"
+                        });
+                        expect(transition.isValid()).is.true;
+
+                        // Set an invalid action id
+                        transition.actionId = nameToId("not this");
+
+                        // Add the transition to the only state of the machine
+                        await expect(fismo.addTransition(machine.id, stateId, transition.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_ACTION_ID);
+
                     });
-                    expect(transition.isValid()).is.true;
 
-                    // Set an invalid target state id
-                    transition.targetStateId = nameToId("not this");
+                    it("Should revert if the target state id is invalid", async function () {
 
-                    // Add the transition to the only state of the machine
-                    await expect(fismo.addTransition(machine.id, stateId, transition.toObject()))
-                        .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+                        // Create a new transition instance
+                        transition = Transition.fromObject({
+                            action: "Transcend",
+                            targetStateName: "Enlightenment"
+                        });
+                        expect(transition.isValid()).is.true;
+
+                        // Set an invalid target state id
+                        transition.targetStateId = nameToId("not this");
+
+                        // Add the transition to the only state of the machine
+                        await expect(fismo.addTransition(machine.id, stateId, transition.toObject()))
+                            .to.revertedWith(RevertReasons.INVALID_TARGET_ID);
+
+                    });
 
                 });
 
@@ -676,211 +740,304 @@ describe("Fismo", function() {
 
         });
 
-    });
+        context("📋 IFismoView methods", async function () {
 
-    context("📋 IFismoView methods", async function () {
+            context("👉 getGuardAddress()", async function () {
 
-        context("👉 getGuardAddress()", async function () {
+                beforeEach( async function () {
 
-            beforeEach( async function () {
+                    [operator, operatorArgs, guards, machine] = await deployExample(deployer.address, fismo.address, LockableDoor, gasLimit);
 
-                [operator, operatorArgs, guards, machine] = await deployExample(deployer.address, fismo.address, LockableDoor, gasLimit);
+                });
 
-            });
+                it("Should return the guard address of a guarded selector", async function () {
 
-            it("Should return the guard address of a guarded selector", async function () {
+                    // The selector of the only guard function
+                    selector = nameToId("LockableDoor_Locked_Exit(address,string)");
 
-                // The selector of the only guard function
-                selector = nameToId("LockableDoor_Locked_Exit(address,string)");
+                    // Get the guard logic address
+                    expected = guards[0].contract.address;
 
-                // Get the guard logic address
-                expected = guards[0].contract.address;
+                    guardLogic = await fismo.getGuardAddress(selector);
 
-                guardLogic = await fismo.getGuardAddress(selector);
+                    // Verify that the appropriate address was returned
+                    expect(guardLogic).to.equal(expected);
 
-                // Verify that the appropriate address was returned
-                expect(guardLogic).to.equal(expected);
-
-            });
-
-        });
-
-        context("👉 getLastPosition()", async function () {
-
-            beforeEach( async function () {
-
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
-
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
-
-                // Id of action to invoke
-                action = "Inhale";
-                actionId = nameToId(action);
+                });
 
             });
 
-            it("Should return the last position of a user who has interacted with Fismo", async function () {
+            context("👉 getLastPosition()", async function () {
 
-                // Invoke the action
-                await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
+                beforeEach( async function () {
 
-                // Request the last position of the user
-                [success, positionStruct] = await fismo.getLastPosition(user.address);
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
 
-                // Check for success as reported by the contract
-                expect(success).to.be.true;
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
 
-                // Validate the returned Position
-                position = Position.fromObject(positionStruct);
-                expect(position.isValid()).to.be.true;
+                    // Id of action to invoke
+                    action = "Inhale";
+                    actionId = nameToId(action);
 
-            });
+                });
 
-            it("Should return a zeroed position for a user who has not interacted with Fismo", async function () {
+                it("Should return the last position of a user who has interacted with Fismo", async function () {
 
-                // Request the last position of the user
-                [success, positionStruct] = await fismo.getLastPosition(user.address);
-
-                // Check for success as reported by the contract
-                expect(success).to.be.false;
-
-                // Validate the returned Position (zeroed fields not considered valid)
-                position = Position.fromObject(positionStruct);
-                expect(position.isValid()).to.be.false;
-
-            });
-
-        });
-
-        context("👉 getPositionHistory()", async function () {
-
-            beforeEach( async function () {
-
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
-
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
-
-                // Id of action to invoke
-                action = "Inhale";
-                actionId = nameToId(action);
-
-            });
-
-            it("Should return the position history for a user who has interacted with Fismo", async function () {
-
-                // In this single-state machine, the actions return to the same state and so, are repeatable
-
-                // Invoke the action several times
-                let totalPositions = 5;
-                for (let i = 0; i < totalPositions; i++) {
+                    // Invoke the action
                     await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
-                }
 
-                // Request the position history of the user
-                [success, response] = await fismo.getPositionHistory(user.address);
+                    // Request the last position of the user
+                    [success, positionStruct] = await fismo.getLastPosition(user.address);
 
-                // Check for success as reported by the contract
-                expect(success).to.be.true;
+                    // Check for success as reported by the contract
+                    expect(success).to.be.true;
 
-                // Response should be an array
-                expect(Array.isArray(response));
+                    // Validate the returned Position
+                    position = Position.fromObject(positionStruct);
+                    expect(position.isValid()).to.be.true;
 
-                // There should be an entry for the new position recorded after the each invoked action
-                expect(response.length === totalPositions).to.be.true;
+                });
 
-                // Validate the returned Position array
-                expect(Position.positionHistoryIsValid(response)).to.be.true;
+                it("Should return a zeroed position for a user who has not interacted with Fismo", async function () {
+
+                    // Request the last position of the user
+                    [success, positionStruct] = await fismo.getLastPosition(user.address);
+
+                    // Check for success as reported by the contract
+                    expect(success).to.be.false;
+
+                    // Validate the returned Position (zeroed fields not considered valid)
+                    position = Position.fromObject(positionStruct);
+                    expect(position.isValid()).to.be.false;
+
+                });
 
             });
 
-            it("Should return an empty array for a user who has not interacted with Fismo", async function () {
+            context("👉 getPositionHistory()", async function () {
 
-                // User has never interacted, so expect...
-                let totalPositions = 0;
+                beforeEach( async function () {
 
-                // Request the position history of the user
-                [success, response] = await fismo.getPositionHistory(user.address);
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
 
-                // Response should be an array
-                expect(Array.isArray(response));
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
 
-                // There should no positions
-                expect(response.length === totalPositions).to.be.true;
+                    // Id of action to invoke
+                    action = "Inhale";
+                    actionId = nameToId(action);
+
+                });
+
+                it("Should return the position history for a user who has interacted with Fismo", async function () {
+
+                    // In this single-state machine, the actions return to the same state and so, are repeatable
+
+                    // Invoke the action several times
+                    let totalPositions = 5;
+                    for (let i = 0; i < totalPositions; i++) {
+                        await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
+                    }
+
+                    // Request the position history of the user
+                    [success, response] = await fismo.getPositionHistory(user.address);
+
+                    // Check for success as reported by the contract
+                    expect(success).to.be.true;
+
+                    // Response should be an array
+                    expect(Array.isArray(response));
+
+                    // There should be an entry for the new position recorded after the each invoked action
+                    expect(response.length === totalPositions).to.be.true;
+
+                    // Validate the returned Position array
+                    expect(Position.positionHistoryIsValid(response)).to.be.true;
+
+                });
+
+                it("Should return an empty array for a user who has not interacted with Fismo", async function () {
+
+                    // User has never interacted, so expect...
+                    let totalPositions = 0;
+
+                    // Request the position history of the user
+                    [success, response] = await fismo.getPositionHistory(user.address);
+
+                    // Response should be an array
+                    expect(Array.isArray(response));
+
+                    // There should no positions
+                    expect(response.length === totalPositions).to.be.true;
+
+                });
+
+            });
+
+            context("👉 getUserState()", async function () {
+
+                beforeEach( async function () {
+
+                    machine = Machine.fromObject(machineObj);
+                    expect(machine.isValid()).is.true;
+
+                    // Add machine to Fismo
+                    await fismo.installMachine(machine.toObject());
+
+                    // In this single-state machine, the actions return to the same state and are repeatable
+                    // Add another state for these tests, since even with no interaction, the machine's initial state
+                    // would be returned.
+
+                    // Id of action to invoke
+                    action = "Transcend";
+                    actionId = nameToId(action);
+                    targetStateName = "Enlightenment";
+                    targetStateId = nameToId(targetStateName);
+
+                    // Define a simple end state, no transitions
+                    state = State.fromObject({
+                        "name": targetStateName,
+                        "enterGuarded": false,
+                        "exitGuarded": false
+                    });
+
+                    // Add the state to the existing machine
+                    await fismo.addState(machine.id, state.toObject());
+
+                    // Create a new transition instance
+                    transition = Transition.fromObject({
+                        action,
+                        targetStateName
+                    });
+
+                    // Add a transition from the previous state of the machine to the new state
+                    await fismo.addTransition(machine.id, stateId, transition.toObject());
+
+                });
+
+                it("Should return the current state id of a user who has interacted with a given machine", async function () {
+
+                    // Invoke the action
+                    await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
+
+                    // Request the current state id of the user in the given machine
+                    response = await fismo.getUserState(user.address, machine.id);
+
+                    // Validate the returned stateId
+                    expect(response === targetStateId).to.be.true;
+
+                });
+
+                it("Should return a machine's initial state for a user who has not interacted with a it", async function () {
+
+                    // Request the current state id of the user in the given machine
+                    response = await fismo.getUserState(user.address, machine.id);
+
+                    // Validate the returned stateId
+                    expect(response === stateId).to.be.true;
+
+                });
+
+            });
+
+            context("👉 supportsInterface()", async function () {
+
+                it("should indicate support for ERC-165 interface", async function () {
+
+                    // See https://eips.ethereum.org/EIPS/eip-165#how-a-contract-will-publish-the-interfaces-it-implements
+                    support = await fismo.supportsInterface(InterfaceIds.IERC165);
+
+                    // Test
+                    await expect(
+                        support,
+                        "ERC-165 interface not supported"
+                    ).is.true;
+
+                });
+
+                it("should indicate support for IFismoOperate interface", async function () {
+
+                    // Current interfaceId for IFismoOperate
+                    support = await fismo.supportsInterface(InterfaceIds.IFismoOperate);
+
+                    // Test
+                    await expect(
+                        support,
+                        "IFismoOperate interface not supported"
+                    ).is.true;
+
+                });
+
+                it("should indicate support for IFismoUpdate interface", async function () {
+
+                    // Current interfaceId for IFismoUpdate
+                    support = await fismo.supportsInterface(InterfaceIds.IFismoUpdate);
+
+                    // Test
+                    await expect(
+                        support,
+                        "IFismoUpdate interface not supported"
+                    ).is.true;
+
+                });
+
+                it("should indicate support for IFismoView interface", async function () {
+
+                    // Current interfaceId for IFismoView
+                    support = await fismo.supportsInterface(InterfaceIds.IFismoView);
+
+                    // Test
+                    await expect(
+                        support,
+                        "IFismoView interface not supported"
+                    ).is.true;
+
+                });
+
+                it("should not indicate support for a random interface", async function () {
+
+                    // An invalid
+                    support = await fismo.supportsInterface(InterfaceIds.IInvalidRandom);
+
+                    // Test
+                    await expect(
+                        support,
+                        "Random interface oddly supported?"
+                    ).is.false;
+
+                });
+
+                it("should conditionally indicate support for IFismoClone interface", async function () {
+
+                    // Current interfaceId for IFismoOperate
+                    support = await fismo.supportsInterface(InterfaceIds.IFismoClone);
+
+                    // Test conditionally (not supported if called on a clone)
+                    if (isFismo) {
+
+                        await expect(
+                            support,
+                            "IFismoClone interface not supported"
+                        ).is.true;
+
+                    } else {
+
+                        await expect(
+                            support,
+                            "IFismoClone interface unexpectedly supported"
+                        ).is.false;
+
+                    }
+
+                });
 
             });
 
         });
 
-        context("👉 getUserState()", async function () {
-
-            beforeEach( async function () {
-
-                machine = Machine.fromObject(machineObj);
-                expect(machine.isValid()).is.true;
-
-                // Add machine to Fismo
-                await fismo.installMachine(machine.toObject());
-
-                // In this single-state machine, the actions return to the same state and are repeatable
-                // Add another state for these tests, since even with no interaction, the machine's initial state
-                // would be returned.
-
-                // Id of action to invoke
-                action = "Transcend";
-                actionId = nameToId(action);
-                targetStateName = "Enlightenment";
-                targetStateId = nameToId(targetStateName);
-
-                // Define a simple end state, no transitions
-                state = State.fromObject({
-                    "name": targetStateName,
-                    "enterGuarded": false,
-                    "exitGuarded": false
-                });
-
-                // Add the state to the existing machine
-                await fismo.addState(machine.id, state.toObject());
-
-                // Create a new transition instance
-                transition = Transition.fromObject({
-                    action,
-                    targetStateName
-                });
-
-                // Add a transition from the previous state of the machine to the new state
-                await fismo.addTransition(machine.id, stateId, transition.toObject());
-
-            });
-
-            it("Should return the current state id of a user who has interacted with a given machine", async function () {
-
-                // Invoke the action
-                await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
-
-                // Request the current state id of the user in the given machine
-                response = await fismo.getUserState(user.address, machine.id);
-
-                // Validate the returned stateId
-                expect(response === targetStateId).to.be.true;
-
-            });
-
-            it("Should return a machine's initial state for a user who has not interacted with a it", async function () {
-
-                // Request the current state id of the user in the given machine
-                response = await fismo.getUserState(user.address, machine.id);
-
-                // Validate the returned stateId
-                expect(response === stateId).to.be.true;
-
-            });
-
-        });
-
-    });
+    }
 
 });

--- a/test/unit/SupportedInterfacesTest.js
+++ b/test/unit/SupportedInterfacesTest.js
@@ -22,7 +22,7 @@ const { InterfaceIds } = require('../../scripts/config/supported-interfaces.js')
 describe("SupportedInterfaces", function() {
 
     // Shared args
-    let InterfaceInfo, interfaceInfo;
+    let SupportedInterfaces, supportedInterfaces;
 
     beforeEach( async function () {
 
@@ -33,7 +33,15 @@ describe("SupportedInterfaces", function() {
 
     });
 
-    context("📋 Supported Interfaces", async function () {;
+    context("📋 Supported Interfaces", async function () {
+
+        it("getIFismoClone() should return expected id", async function () {
+
+            const expected = InterfaceIds.IFismoClone;
+            const actual = await supportedInterfaces.getIFismoClone();
+            assert.equal(actual, expected);
+
+        });
 
         it("getIFismoOperate() should return expected id", async function () {
 


### PR DESCRIPTION
* In deploy-and-verify-all.js & deploy-fismo.js,
  - Removed arguments for Fismo, it will be the deployer who owns the contract by default.

* In Fismo.sol
  - import and extend FismoClone.sol
  - in constructor
    - removed owner arg
    - set owner to msg.sender
    - set isFismo to true

* Refactor/moved FismoStore.sol
  - from contracts/components
  - to contracts/domain

* Added FismoClone.sol,
  - imports and extends IFismoClone.sol and IFismoUpdate.sol
  - init method called when clone is intialized
  - cloneFismo method
    - reverts if calling on a cloned instance
    - calls clone to get an instance
    - calls the instance's init method passing msg.sender as owner
    - emits FismoCloned event
  - clone method
    - ERC-1165 minimal proxy factory

* In FismoConstants.sol,
  - added revert reasons
    - INVALID_ADDRESS
    - MULTIPLICITY

* In FismoOperate.sol,
  - refactor/renamed Transitioned event to UserTransitioned

* In FismoStore.sol,
  - added isFismo boolean to FismoSlot

* In FismoTools.sol,
  - made getGuardSignature internal

* In FismoUpdate.sol
  - added transferOwnership method

* In FismoUpdate.sol
  - added getOwner method
  - added setIsFismo method

* In FismoView.sol,
  - added getOwner method
  - in supportsInterface method
    - made support for IFismoClone depend on isFismo being true

* Added IFismoClone.sol

* In IFismoOperate.sol,
  - refactor/renamed Transitioned event to UserTransitioned

* In IFismoUpdate.sol,
  - added OwnershipTransferred event
  - added transferOwnership method

* In IFismoView.sol,
  - added getOwner method

* In SupportedInterfaces.sol,
  - added getIFismoClone method

* In FismoTest.js,
  - refactored to run all tests twice,
    - As a standalone contract, called directly"
    - "As a logic contract, called via clone proxy"
  - added tests
    - for supportsInterface()
      - "should conditionally indicate support for IFismoClone interface"
    - for cloneFismo()
      - "Should create a clone of the Fismo contract for any caller"
      - "Should emit a FismoCloned event with owner and instance addresses"

* In LockableDoorTest.js,
       - refactor/renamed Transitioned event to UserTransitioned

* In SupportedInterfacesTest.js,
  - added test for getIFismoClone method

* In revert-reasons.js,
  - added MULTIPLICITY revert reason

* In supported-interfaces.js,
  - updated all interface ids

* Updated all API docs