### PR TITLE
State getter and struct marshaling

### DIFF
--- a/contracts/components/FismoOperate.sol
+++ b/contracts/components/FismoOperate.sol
@@ -37,7 +37,9 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
      * @param _user - the address of the user
      * @param _machineId - the id of the target machine
      * @param _actionId - the id of the action to invoke
-     */
+     *
+     * @return response - the response from the action. See {FismoTypes.ActionResponse}
+        */
     function invokeAction(
         address _user,
         bytes4 _machineId,
@@ -51,14 +53,11 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
         // Get the machine
         Machine storage machine = getMachine(_machineId);
 
-        // Get the user's current state id in the machine
-        bytes4 currentStateId = getUserState(_user, _machineId);
-
-        // Get that state's index in the machine's states array
-        uint256 index = getStateIndex(_machineId, currentStateId);
+        // Get the user's current state in the given machine
+        bytes4 currentStateId = getUserStateId(_user, _machineId);
 
         // Get the state
-        State storage state = machine.states[index];
+        State storage state = getState(_machineId, currentStateId, true);
 
         // Find the transition triggered by the given action
         Transition memory transition;

--- a/contracts/components/FismoView.sol
+++ b/contracts/components/FismoView.sol
@@ -93,21 +93,19 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
      *
      * @param _user - the address of the user
      * @param _machineId - the id of the machine
-     * @return currentStateId - the user's current state in the given machine
+     * @return state - the user's current state in the given machine. See {FismoTypes.State}
      */
     function getUserState(address _user, bytes4 _machineId)
-    public
+    external
     view
     override
-    returns (bytes4 currentStateId)
+    returns (State memory state)
     {
-        // Get the machine
-        Machine storage machine = getMachine(_machineId);
+        // Get the user's current state in the given machine
+        bytes4 currentStateId = getUserStateId(_user, _machineId);
 
-        // Get the user's current state in the given machine, default to initialStateId if not found
-        currentStateId = getStore().userState[_user][_machineId];
-        if (currentStateId == bytes4(0)) currentStateId = machine.initialStateId;
-
+        // Get the state
+        state = getState(_machineId, currentStateId, true);
     }
 
     /**
@@ -179,6 +177,35 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
     {
         index = getStore().stateIndex[_machineId][_stateId];
     }
+
+    /**
+ * @notice Get the current state for a given user in a given machine.
+     *
+     * Note:
+     * - If the user has not interacted with the machine, the initial state
+     *   for the machine is returned.
+     *
+     * Reverts if:
+     * - machine does not exist
+     *
+     * @param _user - the address of the user
+     * @param _machineId - the id of the machine
+     * @return currentStateId - the user's current state id in the given machine.
+     */
+    function getUserStateId(address _user, bytes4 _machineId)
+    internal
+    view
+    returns (bytes4 currentStateId)
+    {
+        // Get the machine
+        Machine storage machine = getMachine(_machineId);
+
+        // Get the user's current state in the given machine, default to initialStateId if not found
+        currentStateId = getStore().userState[_user][_machineId];
+        if (currentStateId == bytes4(0)) currentStateId = machine.initialStateId;
+
+    }
+
 
     /**
      * @notice Get the function signature for an enter or exit guard guard

--- a/contracts/interfaces/IFismoOperate.sol
+++ b/contracts/interfaces/IFismoOperate.sol
@@ -33,6 +33,8 @@ interface IFismoOperate {
      * @param _user - the address of the user
      * @param _machineId - the id of the target machine
      * @param _actionId - the id of the action to invoke
+     *
+     * @return response - the response from the action. See {FismoTypes.ActionResponse}
      */
     function invokeAction(
         address _user,

--- a/contracts/interfaces/IFismoView.sol
+++ b/contracts/interfaces/IFismoView.sol
@@ -69,11 +69,11 @@ interface IFismoView {
      *
      * @param _user - the address of the user
      * @param _machineId - the id of the machine
-     * @return currentStateId - the user's current state in the given machine
+     * @return state - the user's current state in the given machine. See {FismoTypes.State}
      */
     function getUserState(address _user, bytes4 _machineId)
     external
     view
-    returns (bytes4 currentStateId);
+    returns (FismoTypes.State memory state);
 
 }

--- a/scripts/domain/entity/Machine.js
+++ b/scripts/domain/entity/Machine.js
@@ -40,6 +40,26 @@ class Machine {
     }
 
     /**
+     * Get a new Machine instance from a returned struct representation
+     * @param struct
+     * @returns {*}
+     */
+    static fromStruct(struct) {
+        let operator, id, name, initialStateId, uri, states;
+
+        // destructure struct
+        [operator, id, name, initialStateId, uri, states] = struct;
+        return Machine.fromObject({
+            operator,
+            id,
+            initialStateId: initialStateId,
+            name,
+            uri,
+            states: states.map(state => State.fromStruct(state))
+        });
+    }
+
+    /**
      * Get a database representation of this Machine instance
      * @returns {object}
      */
@@ -53,6 +73,23 @@ class Machine {
      */
     toString() {
         return JSON.stringify(this);
+    }
+
+    /**
+     * Get a struct representation of this Machine instance
+     * @returns {string}
+     */
+    toStruct() {
+        const {operator, name, initialStateId, uri} = this;
+        let states = this.states.map(state => state.toStruct());
+        return [
+            operator,
+            nameToId(name),
+            name,
+            initialStateId,
+            uri,
+            states
+        ];
     }
 
     /**

--- a/scripts/domain/entity/State.js
+++ b/scripts/domain/entity/State.js
@@ -41,6 +41,28 @@ class State {
     }
 
     /**
+     * Get a new State instance from a struct representation
+     * @param struct
+     * @returns {*}
+     */
+    static fromStruct(struct) {
+        let id, name, exitGuarded, enterGuarded, guardLogic, transitions;
+
+        // destructure struct
+        [id, name, exitGuarded, enterGuarded, guardLogic, transitions] = struct;
+        return State.fromObject({
+            id,
+            name,
+            exitGuarded,
+            enterGuarded,
+            guardLogic,
+            transitions: transitions
+                ? transitions.map(transition => Transition.fromStruct(transition))
+                : []
+        });
+    }
+
+    /**
      * Get a database representation of this State instance
      * @returns {object}
      */
@@ -54,6 +76,23 @@ class State {
      */
     toString() {
         return JSON.stringify(this);
+    }
+
+    /**
+     * Get a struct representation of this State instance
+     * @returns {string}
+     */
+    toStruct() {
+        const {name, exitGuarded, enterGuarded, guardLogic} = this;
+        let transitions = this.transitions.map(transition => transition.toStruct());
+        return [
+            nameToId(name),
+            name,
+            exitGuarded,
+            enterGuarded,
+            guardLogic,
+            transitions
+        ];
     }
 
     /**

--- a/scripts/domain/entity/Transition.js
+++ b/scripts/domain/entity/Transition.js
@@ -33,6 +33,24 @@ class Transition {
     }
 
     /**
+     * Get a new Transition instance from a struct representation
+     * @param struct
+     * @returns {*}
+     */
+    static fromStruct(struct) {
+        let actionId, targetStateId, action, targetStateName;
+
+        // destructure struct
+        [actionId, targetStateId, action, targetStateName] = struct;
+        return Transition.fromObject({
+            actionId: actionId.toString(),
+            targetStateId: targetStateId.toString(),
+            action,
+            targetStateName
+        });
+    }
+
+    /**
      * Get a database representation of this Transition instance
      * @returns {object}
      */
@@ -46,6 +64,20 @@ class Transition {
      */
     toString() {
         return JSON.stringify(this);
+    }
+
+    /**
+     * Get a struct representation of this Transition instance
+     * @returns {string}
+     */
+    toStruct() {
+        const {action, actionId, targetStateName, targetStateId} = this;
+        return [
+            actionId,
+            targetStateId,
+            action,
+            targetStateName,
+        ];
     }
 
     /**

--- a/test/domain/MachineTest.js
+++ b/test/domain/MachineTest.js
@@ -11,8 +11,8 @@ const { State, Machine, Transition, nameToId } = require("../../scripts/domain")
 describe("Machine", function() {
 
     // Suite-wide scope
-    let machine, object, dehydrated, rehydrated, clone, state, stateName;
-    let accounts, operator, name, states, initialStateId, uri;
+    let machine, object, struct, dehydrated, rehydrated, promoted, clone, state, stateName;
+    let accounts, operator, id, name, states, initialStateId, uri;
 
     beforeEach( async function () {
 
@@ -47,7 +47,9 @@ describe("Machine", function() {
 
         // Machine
         name = "Lockable_Door";
+        id = nameToId(name);
         initialStateId = states[0].id;
+        uri = "https://ipfs.io/ipfs/Qsomething";
 
     });
 
@@ -250,14 +252,15 @@ describe("Machine", function() {
             beforeEach( async function () {
 
                 machine =  new Machine(operator, name, states, initialStateId, uri);
-                object = { operator, name, states, initialStateId, uri };
+                object = { operator, id, name, initialStateId, uri, states };
+                struct = [ operator, id, name, initialStateId, uri, states.map(state => state.toStruct()) ]
 
             });
 
             it("Machine.fromObject() should return a Machine instance with the same values as the given plain object", async function () {
 
                 // Promote to instance
-                const promoted = Machine.fromObject(object);
+                promoted = Machine.fromObject(object);
 
                 // Is a Machine instance
                 expect(promoted instanceof Machine).is.true;
@@ -266,6 +269,16 @@ describe("Machine", function() {
                 for (const [key, value] of Object.entries(machine)) {
                     expect(JSON.stringify(promoted[key]) === JSON.stringify(value)).is.true;
                 }
+
+            });
+
+            it("Machine.fromStruct() should return a Machine instance from a struct representation", async function () {
+
+                // Get struct from instance
+                machine = Machine.fromStruct(struct);
+
+                // Ensure it is valid
+                expect(machine.isValid()).to.be.true;
 
             });
 
@@ -317,6 +330,19 @@ describe("Machine", function() {
                 for (const [key, value] of Object.entries(machine)) {
                     expect(JSON.stringify(object[key]) === JSON.stringify(value)).is.true;
                 }
+
+            });
+
+            it("instance.toStruct() should return a struct representation of the Machine instance", async function () {
+
+                // Get struct from machine
+                struct = machine.toStruct();
+
+                // Marshal back to a machine instance
+                machine = Machine.fromStruct(struct);
+
+                // Ensure it marshals back to a valid machine
+                expect(machine.isValid()).to.be.true;
 
             });
 

--- a/test/domain/StateTest.js
+++ b/test/domain/StateTest.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { State, Transition, nameToId } = require("../../scripts/domain");
+const { State, Transition, nameToId, Machine} = require("../../scripts/domain");
 
 /**
  *  Test the State domain object
@@ -9,13 +9,14 @@ const { State, Transition, nameToId } = require("../../scripts/domain");
 describe("State", function() {
 
     // Suite-wide scope
-    let state, object, dehydrated, rehydrated, clone;
-    let name, guardLogic, transitions, exitGuarded, enterGuarded;
+    let state, object, dehydrated, rehydrated, struct, clone;
+    let id, name, guardLogic, transitions, exitGuarded, enterGuarded;
 
     beforeEach( async function () {
 
         // Locked state of a door that can be unlocked with a key and locked without a key
         name = "Locked";
+        id = nameToId(name);
         exitGuarded = true;
         enterGuarded = false;
         transitions = [
@@ -229,7 +230,8 @@ describe("State", function() {
             beforeEach( async function () {
 
                 state = new State(name, exitGuarded, enterGuarded, transitions, guardLogic);
-                object = { name,  transitions, exitGuarded, enterGuarded, guardLogic };
+                object = { id, name, transitions, exitGuarded, enterGuarded, guardLogic };
+                struct = [ id, name, exitGuarded, enterGuarded, guardLogic, transitions.map(transition => transition.toStruct()) ];
 
             });
 
@@ -245,6 +247,16 @@ describe("State", function() {
                 for (const [key, value] of Object.entries(state)) {
                     expect(JSON.stringify(promoted[key]) === JSON.stringify(value)).is.true;
                 }
+
+            });
+
+            it("State.fromStruct() should return a State instance from a struct representation", async function () {
+
+                // Get struct from instance
+                state = State.fromStruct(struct);
+
+                // Ensure it is valid
+                expect(state.isValid()).to.be.true;
 
             });
 
@@ -269,18 +281,16 @@ describe("State", function() {
 
             });
 
-            it("instance.clone() should return another State instance with the same property values", async function() {
+            it("instance.toStruct() should return a struct representation of the State instance", async function () {
 
-                // Get plain object
-                clone = state.clone();
+                // Get struct from state
+                struct = state.toStruct();
 
-                // Is an State instance
-                expect(clone instanceof State).is.true;
+                // Marshal back to a state instance
+                state = State.fromStruct(struct);
 
-                // Key values all match
-                for (const [key, value] of Object.entries(state)) {
-                    expect(JSON.stringify(clone[key]) === JSON.stringify(value)).is.true;
-                }
+                // Ensure it marshals back to a valid state
+                expect(state.isValid()).to.be.true;
 
             });
 
@@ -295,6 +305,21 @@ describe("State", function() {
                 // Key values all match
                 for (const [key, value] of Object.entries(state)) {
                     expect(JSON.stringify(object[key]) === JSON.stringify(value)).is.true;
+                }
+
+            });
+
+            it("instance.clone() should return another State instance with the same property values", async function() {
+
+                // Get plain object
+                clone = state.clone();
+
+                // Is an State instance
+                expect(clone instanceof State).is.true;
+
+                // Key values all match
+                for (const [key, value] of Object.entries(state)) {
+                    expect(JSON.stringify(clone[key]) === JSON.stringify(value)).is.true;
                 }
 
             });

--- a/test/domain/TransitionTest.js
+++ b/test/domain/TransitionTest.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { Transition, nameToId } = require("../../scripts/domain");
+const { Transition, nameToId, State} = require("../../scripts/domain");
 
 /**
  *  Test the Transition domain object
@@ -9,13 +9,15 @@ const { Transition, nameToId } = require("../../scripts/domain");
 describe("Transition", function() {
 
     // Suite-wide scope
-    let transition, object, dehydrated, rehydrated, clone;
-    let action, targetStateName;
+    let transition, object, dehydrated, rehydrated, struct, clone;
+    let actionId, targetStateId, action, targetStateName;
 
     beforeEach( async function () {
 
         action = "Disappear in a Puff of Smoke";  // Action names can have spaces as they're never part of a method name
-        targetStateName = "Inside_Puff_of_Smoke"; // State names cannot have no spaces
+        targetStateName = "Inside_Puff_of_Smoke"; // State names cannot have spaces
+        actionId = nameToId(action);
+        targetStateId = nameToId(targetStateName);
 
     });
 
@@ -153,6 +155,7 @@ describe("Transition", function() {
 
                 transition = new Transition(action, targetStateName);
                 object = { action, targetStateName };
+                struct = [ actionId, targetStateName, action, targetStateName];
 
             });
 
@@ -168,6 +171,16 @@ describe("Transition", function() {
                 for (const [key, value] of Object.entries(transition)) {
                     expect(JSON.stringify(promoted[key]) === JSON.stringify(value)).is.true;
                 }
+
+            });
+
+            it("Transition.fromStruct() should return a Transition instance from a struct representation", async function () {
+
+                // Get struct from instance
+                transition = Transition.fromStruct(struct);
+
+                // Ensure it is valid
+                expect(transition.isValid()).to.be.true;
 
             });
 
@@ -192,18 +205,16 @@ describe("Transition", function() {
 
             });
 
-            it("instance.clone() should return another Transition instance with the same property values", async function() {
+            it("instance.toStruct() should return a struct representation of the Transition instance", async function () {
 
-                // Get plain object
-                clone = transition.clone();
+                // Get struct from transition
+                struct = transition.toStruct();
 
-                // Is an Transition instance
-                expect(clone instanceof Transition).is.true;
+                // Marshal back to a transition instance
+                transition = Transition.fromStruct(struct);
 
-                // Key values all match
-                for (const [key, value] of Object.entries(transition)) {
-                    expect(JSON.stringify(clone[key]) === JSON.stringify(value)).is.true;
-                }
+                // Ensure it marshals back to a valid transition
+                expect(transition.isValid()).to.be.true;
 
             });
 
@@ -218,6 +229,21 @@ describe("Transition", function() {
                 // Key values all match
                 for (const [key, value] of Object.entries(transition)) {
                     expect(JSON.stringify(object[key]) === JSON.stringify(value)).is.true;
+                }
+
+            });
+
+            it("instance.clone() should return another Transition instance with the same property values", async function() {
+
+                // Get plain object
+                clone = transition.clone();
+
+                // Is an Transition instance
+                expect(clone instanceof Transition).is.true;
+
+                // Key values all match
+                for (const [key, value] of Object.entries(transition)) {
+                    expect(JSON.stringify(clone[key]) === JSON.stringify(value)).is.true;
                 }
 
             });

--- a/test/unit/FismoTest.js
+++ b/test/unit/FismoTest.js
@@ -214,8 +214,6 @@ describe("Fismo", function() {
     // Tests to be run against Fismo and Fismo clone
     function testFismo() {
 
-        // TODO: IFismoClone methods
-
         context("📋 IFismoOperate methods", async function () {
 
             context("👉 invokeAction()", async function () {
@@ -1232,7 +1230,7 @@ describe("Fismo", function() {
 
                 });
 
-                it("Should return the current state id of a user who has interacted with a given machine", async function () {
+                it("Should return the current state of a user who has interacted with a given machine", async function () {
 
                     // Invoke the action
                     await fismo.connect(operator).invokeAction(user.address, machine.id, actionId);
@@ -1240,18 +1238,36 @@ describe("Fismo", function() {
                     // Request the current state id of the user in the given machine
                     response = await fismo.getUserState(user.address, machine.id);
 
-                    // Validate the returned stateId
-                    expect(response === targetStateId).to.be.true;
+                    // Flatten the current representation of the machine's single state
+                    expected = state.toString();
+
+                    // Get the state from the struct
+                    state = State.fromStruct(response);
+
+                    // Validate the returned state
+                    expect(state.isValid()).to.be.true;
+
+                    // Compare state to state
+                    expect(state.toString() === expected).to.be.true;
 
                 });
 
                 it("Should return a machine's initial state for a user who has not interacted with a it", async function () {
 
+                    // Flatten the current representation of the machine's single state
+                    expected = machine.states[0].name;
+
                     // Request the current state id of the user in the given machine
                     response = await fismo.getUserState(user.address, machine.id);
 
-                    // Validate the returned stateId
-                    expect(response === stateId).to.be.true;
+                    // Get the state from the struct
+                    state = State.fromStruct(response);
+
+                    // Validate the returned state
+                    expect(state.isValid()).to.be.true;
+
+                    // Compare state name to state name
+                    expect(state.name === expected).to.be.true;
 
                 });
 


### PR DESCRIPTION
Fetching the full state struct rather than just the ID is more useful to clients. It also prepares us for a hook that allows a guard logic contract to expose an action list filter

* In FismoOperate.sol,
  - in invokeAction method,
    - call getUserStateId to get the current state for the user
    - call getState to get the state

* In FismoView.sol,
  - in getUserState method,
    - changed the return value to be a State
    - get the current state for the user from getUserStateId
    - get and return the state from getState

* In IFismoView.sol,
  - in getUserState method,
    - changed the return value to be a State

* In IFismoOperate.sol,
  - add return value of invokeAction to natspec

* In FismoTest.js,
  - remove finished todo
  - updated getUserState methods to expect the appropriate returned state struct rather than a state id

* In Machine.js, State.js, and Transition.js
  - added methods
    - toStruct()
    - fromStruct()

* In MachineTest.js, StateTest.js, and TransitionTest.js
  - added tests for
    - machine.toStruct()
    - Machine.fromStruct()