### PR TITLE
Action list filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Done or in progress are:
 - ✅ Developer setup and tasks documentation
 - ✅ Developer environment configuration template
 - ✅ High level architecture documentation
-- ✅ Finalize API
-- 👉 State-specific action list filter in guard contracts
+- ✅ Contextually filter actions on guard contracts
 - 👉 Complete code coverage
 - 👉 Complete NPM package
 - 👉 Deploy to testnets, mainnet, sidechains

--- a/contracts/components/FismoOperate.sol
+++ b/contracts/components/FismoOperate.sol
@@ -60,18 +60,28 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
         State storage state = getState(_machineId, currentStateId, true);
 
         // Find the transition triggered by the given action
+        bool found = false;
         Transition memory transition;
-        bool valid = false;
-        for (uint32 i = 0; i < state.transitions.length; i++) {
+        for (uint256 i = 0; i < state.transitions.length; i++) {
+
+            // We found it...
             if (state.transitions[i].actionId == _actionId) {
-                valid = true;
+                found = true;
                 transition = state.transitions[i];
                 break;
             }
+
         }
 
-        // Make sure transition was found
-        require(valid == true, NO_SUCH_ACTION);
+        // Determine if action is suppressed
+        bool suppressed =
+            !found || (                                      // invalid action
+                (state.exitGuarded || state.enterGuarded) && // state is guarded and thus may filter
+                isActionSuppressed(_user, state.guardLogic, machine.name, state.name, transition.action)
+            );
+
+        // Make sure transition was found and not suppressed
+        require(!suppressed, NO_SUCH_ACTION);
 
         // Get the next state
         State storage nextState = getState(_machineId, transition.targetStateId, true);
@@ -84,12 +94,12 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
 
         // if there is exit guard logic for the current state, call it
         if (state.exitGuarded) {
-            response.exitMessage = invokeGuard(_user, machine.name, state.name, Guard.Exit);
+            response.exitMessage = invokeGuard(_user, state.guardLogic, machine.name, state.name, Guard.Exit);
         }
 
         // if there is enter guard logic for the next state, call it
         if (nextState.enterGuarded) {
-            response.enterMessage = invokeGuard(_user, machine.name, nextState.name, Guard.Enter);
+            response.enterMessage = invokeGuard(_user, nextState.guardLogic, machine.name, nextState.name, Guard.Enter);
         }
 
         // if we made it this far, set the new state
@@ -109,14 +119,16 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
      * - delegatecall attempt fails for any other reason
      *
      * @param _user - the user address the call is being invoked for
+     * @param _guardLogic - the address of the guard logic contract
      * @param _machineName - the name of the machine
      * @param _stateName - the name of the state
-     * @param _guard - the guard type (enter/exit) See: {Guard}
+     * @param _guard - the guard type (enter/exit) See: {FismoTypes.Guard}
      *
      * @return guardResponse - the message (if any) returned from the guard
      */
     function invokeGuard(
         address _user,
+        address _guardLogic,
         string memory _machineName,
         string memory _stateName,
         Guard _guard
@@ -132,12 +144,8 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
             _stateName
         );
 
-        // Get the guard implementation address
-        address guardAddress = getGuardAddress(selector);
-        require(guardAddress != address(0), NO_SUCH_GUARD);
-
         // Invoke the guard
-        (bool success, bytes memory response) = guardAddress.delegatecall(guardCall);
+        (bool success, bytes memory response) = _guardLogic.delegatecall(guardCall);
 
         // if the function call reverted
         if (success == false) {

--- a/contracts/domain/FismoTypes.sol
+++ b/contracts/domain/FismoTypes.sol
@@ -12,7 +12,8 @@ contract FismoTypes {
 
     enum Guard {
         Enter,
-        Exit
+        Exit,
+        Filter // only valid internally
     }
 
     struct Machine {

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -35,10 +35,4 @@ exports.RevertReasons = {
     CODELESS_GUARD: "Guard address not a contract",
     GUARD_REVERTED: "Guard function reverted, no reason given",
 
-    // --------------------------------------------------------
-    // LOCKABLE DOOR EXAMPLE
-    // --------------------------------------------------------
-    USER_MUST_HAVE_KEY: "User must hold key to unlock."
-
-
 };

--- a/scripts/domain/entity/State.js
+++ b/scripts/domain/entity/State.js
@@ -48,6 +48,7 @@ class State {
     static fromStruct(struct) {
         let id, name, exitGuarded, enterGuarded, guardLogic, transitions;
 
+
         // destructure struct
         [id, name, exitGuarded, enterGuarded, guardLogic, transitions] = struct;
         return State.fromObject({

--- a/test/lab/LockableDoorTest.js
+++ b/test/lab/LockableDoorTest.js
@@ -32,7 +32,7 @@ describe("Lockable Door Machine", function() {
     // Common vars
     let accounts, deployer, user, operator, operatorArgs, guards, tokens, keyToken;
     let fismo, example, machine, machineId, action, actionId, stateId;
-    let actionResponse, actionResponseStruct;
+    let actionResponse, actionResponseStruct, amountToMint;
     let priorState, nextState, exitMessage, enterMessage;
 
     beforeEach( async function () {
@@ -229,7 +229,8 @@ describe("Lockable Door Machine", function() {
                     actionId = nameToId(action);
 
                     // Attempt to invoke the action via the Operator, checking for the generic revert reason
-                    // Note: This guard will revert with no reason if the owner attempts to use it. (Contrived)
+                    // Note: This guard will revert with no reason if the contract owner attempts to use it.
+                    //       Yes, this is contrived, but code coverage, yo.
                     await expect(operator.connect(deployer).invokeAction(machine.id, actionId))
                         .to.revertedWith(RevertReasons.GUARD_REVERTED);
 
@@ -266,9 +267,10 @@ describe("Lockable Door Machine", function() {
                     exitMessage = "Door unlocked.";
                     stateId = nameToId(nextState);
 
-                    // Invoke the action via the Operator, checking for the custom revert reason
+                    // Invoke the action via the Operator
+                    // Action will be suppressed, since user does not have key
                     await expect(operator.connect(user).invokeAction(machine.id, actionId))
-                        .to.revertedWith(RevertReasons.USER_MUST_HAVE_KEY);
+                        .to.revertedWith(RevertReasons.NO_SUCH_ACTION);
 
                 });
 


### PR DESCRIPTION
* In FismoOperate.sol,
  - in invokeAction method
    - determine if action is suppressed
      - if state is guarded, it can filter
      - call isActionSuppressed
      - pass state.guardLogic to invokeGuard
    - in invokeGuard method,
      - added _guardLogic argument
      - remove call to getGuardAddress
      - invoke delegate call on _guardLogic

* In FismoTypes.sol,
  - in Guard enum
    - added Filter setting for internal use only

* In LockableDoorGuards.sol,
  - added LockableDoor_Locked_Filter
    - responds with suppress as true if action is Unlock and user does not have key
  - in LockableDoor_Locked_Exit,
    - changed to external
    - refactor/extract token balance check to isKeyHolder method, shared with action filter
    - removed "User must hold key to unlock." revert reason because the check is just for form. It will never be called if the user doesn't have the key because the action will have been suppressed and therefore reverted prior to this call. However in a more complex machine multiple actions that could lead to this exit guard being called and only some of them be suppressed, so it is important to keep this check here.

* In LockableDoorTest.js,
  - expect NO_SUCH_ACTION when trying to unlock if you don't have the key

* In revert-reasons.js,
  - removed USER_MUST_HAVE_KEY