### PR TITLE
Enable transition guards to inspect the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each user's position on their journey through a state machine is recorded, and c
 * 💥 Use off-chain metadata to describe states in any medium
 
 ### Status 
-### [![Node.js CI](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml/badge.svg)](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml) 🔬 ![85%](https://progress-bar.dev/87/?title=Progress&width=100&color=000000)
+### [![Node.js CI](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml/badge.svg)](https://github.com/cliffhall/Fismo/actions/workflows/node.js.yml) 🔬 ![89%](https://progress-bar.dev/87/?title=Progress&width=100&color=000000)
 
 Done or in progress are:
 - ✅ Science! a working [Deterministic Selector Proxy](docs/about.md#experimentdeterministicselectorproxy) implementation
@@ -37,7 +37,8 @@ Done or in progress are:
 - ✅ Developer environment configuration template
 - ✅ High level architecture documentation
 - ✅ Contextually filter actions on guard contracts
-- 👉 Complete code coverage
+- ✅ Enable self-targeting transitions to inspect the action
+- ✅ Optimize contract size
 - 👉 Complete NPM package
 - 👉 Deploy to testnets, mainnet, sidechains
 - 👉 Write "How to create, install and operate machines on Fismo" doc

--- a/contracts/components/FismoOperate.sol
+++ b/contracts/components/FismoOperate.sol
@@ -94,12 +94,12 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
 
         // if there is exit guard logic for the current state, call it
         if (state.exitGuarded) {
-            response.exitMessage = invokeGuard(_user, state.guardLogic, machine.name, state.name, Guard.Exit);
+            response.exitMessage = invokeGuard(_user, state.guardLogic, machine.name, state.name, transition.action, Guard.Exit);
         }
 
         // if there is enter guard logic for the next state, call it
         if (nextState.enterGuarded) {
-            response.enterMessage = invokeGuard(_user, nextState.guardLogic, machine.name, nextState.name, Guard.Enter);
+            response.enterMessage = invokeGuard(_user, nextState.guardLogic, machine.name, nextState.name, transition.action, Guard.Enter);
         }
 
         // if we made it this far, set the new state
@@ -121,7 +121,8 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
      * @param _user - the user address the call is being invoked for
      * @param _guardLogic - the address of the guard logic contract
      * @param _machineName - the name of the machine
-     * @param _stateName - the name of the state
+     * @param _action - the name of the state
+     * @param _targetStateName - the name of the target state
      * @param _guard - the guard type (enter/exit) See: {FismoTypes.Guard}
      *
      * @return guardResponse - the message (if any) returned from the guard
@@ -130,18 +131,20 @@ contract FismoOperate is IFismoOperate, FismoSupport  {
         address _user,
         address _guardLogic,
         string memory _machineName,
-        string memory _stateName,
+        string memory _targetStateName,
+        string memory _action,
         Guard _guard
     )
     internal
     returns (string memory guardResponse)
     {
         // Get the function selector and encode the call
-        bytes4 selector = getGuardSelector(_machineName, _stateName, _guard);
+        bytes4 selector = getGuardSelector(_machineName, _targetStateName, _guard);
         bytes memory guardCall = abi.encodeWithSelector(
             selector,
             _user,
-            _stateName
+            _action,
+            _targetStateName
         );
 
         // Invoke the guard

--- a/contracts/components/FismoUpdate.sol
+++ b/contracts/components/FismoUpdate.sol
@@ -158,7 +158,7 @@ contract FismoUpdate is IFismoUpdate, FismoOwner {
      * @param _state - the state to update
      */
     function updateState(bytes4 _machineId, State memory _state)
-    public
+    external
     override
     onlyOwner
     {

--- a/contracts/components/FismoUpdate.sol
+++ b/contracts/components/FismoUpdate.sol
@@ -325,8 +325,6 @@ contract FismoUpdate is IFismoUpdate, FismoOwner {
 
         }
 
-        // Update the the state guards
-        updateStateGuards(_machine, _state);
     }
 
     /**
@@ -341,31 +339,6 @@ contract FismoUpdate is IFismoUpdate, FismoOwner {
     {
         // Add mapping: machine id => state id => states array index
         getStore().stateIndex[_machineId][_stateId] = _index;
-    }
-
-    /**
-     * @notice Update the Gguard function selector mappings for given State.
-     *
-     * @param _machine - the machine. see {Machine}
-     * @param _state - the state. see {State}
-     */
-    function updateStateGuards(Machine memory _machine, State memory _state)
-    internal
-    {
-        // determine enter guard function signature for state
-        // Ex. keccak256 hash of: MachineName_StateName_Enter(address, string memory)
-        bytes4 enterGuardSelector = getGuardSelector(_machine.name, _state.name, Guard.Enter);
-
-        // Map the enter guard function selector to the address of the guard logic implementation for this state
-        getStore().guardLogic[enterGuardSelector] = (_state.enterGuarded) ? _state.guardLogic : address(0);
-
-        // determine exit guard function signature for state
-        // Ex. keccak256 hash of: MachineName_StateName_Exit(address, string memory)
-        bytes4 exitGuardSelector = getGuardSelector(_machine.name, _state.name, Guard.Exit);
-
-        // Map the exit guard function selector to the address of the guard logic implementation for this state
-        getStore().guardLogic[exitGuardSelector] = (_state.exitGuarded) ?  _state.guardLogic : address(0);
-
     }
 
     /**

--- a/contracts/components/FismoView.sol
+++ b/contracts/components/FismoView.sol
@@ -289,49 +289,6 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
     }
 
     /**
-     * @notice Get the function signature for an enter, exit, or filter guard
-     *
-     * e.g.,
-     * `NightClub_Dancefloor_Enter(address _user, string calldata _action, string calldata _priorStateName)`
-     * `NightClub_Dancefloor_Exit(address _user, string calldata _action, string calldata _priorStateName)`
-     * `NightClub_Dancefloor_Filter(address _user, string[] calldata _definedActions)`
-     *
-     * @param _machineName - the name of the machine, e.g., `NightClub`
-     * @param _stateName - the name of the state, e.g., `Dancefloor`
-     * @param _guard - the type of guard (enter/exit/filter). See {FismoTypes.Guard}
-     *
-     * @return guardSignature - a string representation of the function signature
-     */
-    function getGuardSignature(string memory _machineName, string memory _stateName, Guard _guard)
-    internal
-    pure
-    returns (string memory guardSignature)
-    {
-        // Get the guard type as a string
-        string memory guardType =
-            (_guard == Guard.Filter)
-                ? "_Filter"
-                : (_guard == Guard.Enter) ? "_Enter" : "_Exit";
-
-        // Get the function name
-        string memory functionName = strConcat(
-            strConcat(
-                strConcat(_machineName, "_"),
-                _stateName
-            ),
-            guardType
-        );
-
-        // Construct signature
-        guardSignature = strConcat(
-            functionName,
-                (_guard == Guard.Filter)
-                    ? "(address,string)"
-                    : "(address,string,string)"
-        );
-    }
-
-    /**
      * @notice Get the function selector for an enter or exit guard guard
      *
      * @param _machineName - the name of the machine
@@ -345,8 +302,28 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
     pure
     returns (bytes4 guardSelector)
     {
-        // Get the signature
-        string memory guardSignature = getGuardSignature(_machineName, _stateName, _guard);
+        // Get the guard type as a string
+        string memory guardType =
+        (_guard == Guard.Filter)
+        ? "_Filter"
+        : (_guard == Guard.Enter) ? "_Enter" : "_Exit";
+
+        // Get the function name
+        string memory functionName = strConcat(
+            strConcat(
+                strConcat(_machineName, "_"),
+                _stateName
+            ),
+            guardType
+        );
+
+        // Construct signature
+        string memory guardSignature = strConcat(
+            functionName,
+            (_guard == Guard.Filter)
+            ? "(address,string)"
+            : "(address,string,string)"
+        );
 
         // Return the hashed function selector
         guardSelector = nameToId(guardSignature);

--- a/contracts/components/FismoView.sol
+++ b/contracts/components/FismoView.sol
@@ -21,22 +21,6 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
     // EXTERNAL FUNCTIONS
     //-------------------------------------------------------
 
-
-    /**
-     * @notice Get the implementation address for a given guard selector
-     *
-     * @param _functionSelector - the bytes4 sighash of function signature
-     * @return guardAddress - the address of the guard logic implementation contract
-     */
-    function getGuardAddress(bytes4 _functionSelector)
-    public
-    view
-    override
-    returns (address guardAddress)
-    {
-        guardAddress = getStore().guardLogic[_functionSelector];
-    }
-
     /**
      * @notice Get the last recorded position of the given user.
      *
@@ -308,9 +292,9 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
      * @notice Get the function signature for an enter, exit, or filter guard
      *
      * e.g.,
-     * `NightClub_Dancefloor_Enter(address _user, string memory _priorStateName)`
-     * `NightClub_Dancefloor_Exit(address _user, string memory _priorStateName)`
-     * `NightClub_Dancefloor_Filter(address _user, string[] memory _definedActions)`
+     * `NightClub_Dancefloor_Enter(address _user, string calldata _action, string calldata _priorStateName)`
+     * `NightClub_Dancefloor_Exit(address _user, string calldata _action, string calldata _priorStateName)`
+     * `NightClub_Dancefloor_Filter(address _user, string[] calldata _definedActions)`
      *
      * @param _machineName - the name of the machine, e.g., `NightClub`
      * @param _stateName - the name of the state, e.g., `Dancefloor`
@@ -339,7 +323,12 @@ contract FismoView is IFismoView, FismoTypes, FismoConstants {
         );
 
         // Construct signature
-        guardSignature = strConcat(functionName, "(address,string)");
+        guardSignature = strConcat(
+            functionName,
+                (_guard == Guard.Filter)
+                    ? "(address,string)"
+                    : "(address,string,string)"
+        );
     }
 
     /**

--- a/contracts/domain/FismoStore.sol
+++ b/contracts/domain/FismoStore.sol
@@ -22,9 +22,6 @@ library FismoStore {
         // Address of the contract owner
         address owner;
 
-        // Maps a deterministic guard function selector to an implementation address
-        mapping(bytes4 => address) guardLogic;
-
         // Maps machine id to a machine struct
         //      machine id => Machine struct
         mapping(bytes4 => FismoTypes.Machine) machine;

--- a/contracts/domain/FismoTypes.sol
+++ b/contracts/domain/FismoTypes.sol
@@ -13,7 +13,7 @@ contract FismoTypes {
     enum Guard {
         Enter,
         Exit,
-        Filter // only valid internally
+        Filter
     }
 
     struct Machine {

--- a/contracts/interfaces/IFismoView.sol
+++ b/contracts/interfaces/IFismoView.sol
@@ -7,25 +7,11 @@ import { FismoTypes } from "../domain/FismoTypes.sol";
  * @title IFismoView
  *
  * Interface for Fismo view functions
- * The ERC-165 identifier for this interface is 0x26276912
+ * The ERC-165 identifier for this interface is 0x691b5451
  *
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 interface IFismoView {
-
-    /**
-     * @notice Get the implementation address for a given guard selector
-     *
-     * Reverts if
-     * - guard logic implementation is not defined
-     *
-     * @param _functionSelector - the bytes4 sighash of function signature
-     * @return guardAddress - the address of the guard logic implementation contract
-     */
-    function getGuardAddress(bytes4 _functionSelector)
-    external
-    view
-    returns (address guardAddress);
 
     /**
      * @notice Get the last recorded position of the given user.

--- a/contracts/lab/LockableDoor/LockableDoorGuards.sol
+++ b/contracts/lab/LockableDoor/LockableDoorGuards.sol
@@ -95,7 +95,7 @@ contract LockableDoorGuards is FismoConstants {
 
     // Locked / Exit
     // Valid next states: Closed
-    function LockableDoor_Locked_Exit(address _user, string calldata _nextStateName)
+    function LockableDoor_Locked_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     view
     returns(string memory)

--- a/contracts/lab/NightClub/guards/BarGuards.sol
+++ b/contracts/lab/NightClub/guards/BarGuards.sol
@@ -13,7 +13,7 @@ contract BarGuards is NightClubGuardBase {
 
     // Enter the Bar
     // Valid prior states: Restroom, Dancefloor, VIP Lounge, and Foyer
-    function NightClub_Bar_Enter(address _user, string memory _priorStateName)
+    function NightClub_Bar_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -31,7 +31,7 @@ contract BarGuards is NightClubGuardBase {
 
     // Exit the Bar
     // Valid next states: Restroom, Dancefloor, VIP Lounge, and Foyer
-    function NightClub_Bar_Exit(address _user, string memory _nextStateName)
+    function NightClub_Bar_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/CabGuards.sol
+++ b/contracts/lab/NightClub/guards/CabGuards.sol
@@ -13,7 +13,7 @@ contract CabGuards is NightClubGuardBase {
 
     // Enter the Cab
     // Valid prior states: Street and Home
-    function NightClub_Cab_Enter(address _user, string memory _priorStateName)
+    function NightClub_Cab_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -27,7 +27,7 @@ contract CabGuards is NightClubGuardBase {
 
     // Exit the Cab
     // Valid next states: Street and Home
-    function NightClub_Cab_Exit(address _user, string memory _nextStateName)
+    function NightClub_Cab_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/DancefloorGuards.sol
+++ b/contracts/lab/NightClub/guards/DancefloorGuards.sol
@@ -13,7 +13,7 @@ contract DancefloorGuards is NightClubGuardBase {
 
     // Enter the Dancefloor
     // Valid prior states: Restroom, Bar, VIP Lounge, and Foyer
-    function NightClub_Dancefloor_Enter(address _user, string memory _priorStateName)
+    function NightClub_Dancefloor_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -31,7 +31,7 @@ contract DancefloorGuards is NightClubGuardBase {
 
     // Exit the Dancefloor
     // Valid next states: Restroom, Bar, VIP Lounge, and Foyer
-    function NightClub_Dancefloor_Exit(address _user, string memory _nextStateName)
+    function NightClub_Dancefloor_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/FoyerGuards.sol
+++ b/contracts/lab/NightClub/guards/FoyerGuards.sol
@@ -13,7 +13,7 @@ contract FoyerGuards is NightClubGuardBase {
 
     // Enter the Foyer
     // Valid prior states: Street, Dancefloor, VIP Lounge, Bar, and Restroom
-    function NightClub_Foyer_Enter(address _user, string memory _priorStateName)
+    function NightClub_Foyer_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -33,7 +33,7 @@ contract FoyerGuards is NightClubGuardBase {
 
     // Exit the Foyer
     // Valid next states: Street, Dancefloor, VIP Lounge, Bar, and Restroom
-    function NightClub_Foyer_Exit(address _user, string memory _nextStateName)
+    function NightClub_Foyer_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/RestroomGuards.sol
+++ b/contracts/lab/NightClub/guards/RestroomGuards.sol
@@ -13,7 +13,7 @@ contract RestroomGuards is NightClubGuardBase {
 
     // Enter the Restroom
     // Valid prior states: Dancefloor, Bar, VIP Lounge, and Foyer
-    function NightClub_Restroom_Enter(address _user, string memory _priorStateName)
+    function NightClub_Restroom_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -31,7 +31,7 @@ contract RestroomGuards is NightClubGuardBase {
 
     // Exit the Restroom
     // Valid next states: Dancefloor, Bar, VIP Lounge, and Foyer
-    function NightClub_Restroom_Exit(address _user, string memory _nextStateName)
+    function NightClub_Restroom_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/StreetGuards.sol
+++ b/contracts/lab/NightClub/guards/StreetGuards.sol
@@ -13,7 +13,7 @@ contract StreetGuards is NightClubGuardBase {
 
     // Enter the Street
     // Valid prior states: Foyer and Cab
-    function NightClub_Street_Enter(address _user, string memory _priorStateName)
+    function NightClub_Street_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     pure
     returns(string memory message)
@@ -27,7 +27,7 @@ contract StreetGuards is NightClubGuardBase {
 
     // Exit the Street
     // Valid next states: Foyer and Cab
-    function NightClub_Street_Exit(address _user, string memory _nextStateName)
+    function NightClub_Street_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/NightClub/guards/VIPLoungeGuards.sol
+++ b/contracts/lab/NightClub/guards/VIPLoungeGuards.sol
@@ -13,7 +13,7 @@ contract VIPLoungeGuards is NightClubGuardBase {
 
     // Enter the VIP Lounge
     // Valid prior states: Dancefloor, Restroom, Bar, and Foyer
-    function NightClub_VIP_Lounge_Enter(address _user, string memory _priorStateName)
+    function NightClub_VIP_Lounge_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     view
     returns(string memory message)
@@ -34,7 +34,7 @@ contract VIPLoungeGuards is NightClubGuardBase {
 
     // Exit the VIP Lounge
     // Valid next states: Dancefloor, Restroom, Bar, and Foyer
-    function NightClub_VIP_Lounge_Exit(address _user, string memory _nextStateName)
+    function NightClub_VIP_Lounge_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     pure
     returns(string memory message)

--- a/contracts/lab/StopWatch/StopWatchGuards.sol
+++ b/contracts/lab/StopWatch/StopWatchGuards.sol
@@ -110,7 +110,7 @@ contract StopWatchGuards {
     // Valid prior states: Paused
     // - resets user memory
     // - emits StopWatchReset if previously paused
-    function StopWatch_Ready_Enter(address _user, string memory _priorStateName)
+    function StopWatch_Ready_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     returns(string memory message)
     {
@@ -127,7 +127,7 @@ contract StopWatchGuards {
     // Ready / Exit
     // Valid next states: Running
     // - Stores start time
-    function StopWatch_Ready_Exit(address _user, string memory _nextStateName)
+    function StopWatch_Ready_Exit(address _user, string calldata _action, string calldata _nextStateName)
     external
     returns(string memory message)
     {
@@ -137,7 +137,7 @@ contract StopWatchGuards {
     // Running / Enter
     // Valid prior states: Ready, Paused
     // - emits StopWatchRunning if previously paused
-    function StopWatch_Running_Enter(address _user, string memory _priorStateName)
+    function StopWatch_Running_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     returns(string memory message)
     {
@@ -150,7 +150,7 @@ contract StopWatchGuards {
     // - stores time last paused
     // - calculates & stores time elapsed
     // - emits StopWatchPaused event
-    function StopWatch_Paused_Enter(address _user, string memory _priorStateName)
+    function StopWatch_Paused_Enter(address _user, string calldata _action, string calldata _priorStateName)
     external
     returns(string memory message)
     {
@@ -165,7 +165,7 @@ contract StopWatchGuards {
     // Valid next states: Running
     // - calculates & stores total time paused
     // - calculates and stores time elapsed
-    function StopWatch_Paused_Exit(address _user, string memory _priorStateName)
+    function StopWatch_Paused_Exit(address _user, string calldata _action, string calldata _priorStateName)
     external
     returns(string memory message)
     {

--- a/docs/about.md
+++ b/docs/about.md
@@ -25,7 +25,7 @@ This is where you need to write some code and deploy a guard logic implementatio
 
 In the machine definition for the Locked state, the `exitGuarded` flag should be set to `true` and the `guardLogic` property set to this guard contract's address. When Fismo tries to transition between the Locked state and the Open state, it will attempt to execute the following function by combining machine name, state name, and guard direction.
 
-> `LockableDoor_Locked_Exit(address user, string memory _nextStateName)`
+> `LockableDoor_Locked_Exit(address user, string calldata _action, string calldata _nextStateName)`
 
 This requires a developer to write function signatures in a very specific way, but it nicely demonstrates the Deterministic Selector Proxy concept with no chance of function signature collision, since:
   - Each machine name must be unique  

--- a/docs/api/IFismoView.md
+++ b/docs/api/IFismoView.md
@@ -7,39 +7,9 @@
 
 ### View Fismo Storage
 * View Interface [IFismoView.sol](../../contracts/interfaces/IFismoView.sol)
-* The ERC-165 identifier for this interface is `0x26276912`
+* The ERC-165 identifier for this interface is `0x691b5451`
 
 ## Functions
-### getGuardAddress
-Get the implementation address for a given Guard selector.
-
-**Reverts if**
-- Guard logic implementation is not defined
-
-**Signature**
-```solidity
-function getGuardAddress (
-    bytes4 _functionSelector
-) 
-external 
-view
-returns (
-    address guardAddress
-);
-```
-
-**Arguments**
-
-| Name        |  Description |Type           |
-| ------------- |------------- |-------------|
-| _functionSelector | the bytes4 sighash of function signature | bytes4      |  
-
-**Return Values**
-
-| Name        | Description                                | Type           |
-| ------------- |--------------------------------------------|------------- |
-| guardAddress | the address of the guard logic implementation contract| address |
-
 ### getLastPosition
 Get the last recorded position of the given user.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,8 +93,8 @@ It executes...
     - Except, function signatures on Fismo's proxied logic contracts are...
       - Deterministic. Based on the machine and the states involved in a transition.
       - Guard function signatures look like this: 
-        - `MachineName_StateName_Enter(address _user, string memory _priorStateName)` 
-        - `MachineName_StateName_Exit(address _user, string memory _nextStateName)`.
+        - `MachineName_StateName_Enter(address _user, string calldata _action, string memory _priorStateName)` 
+        - `MachineName_StateName_Exit(address _user, string calldata _action, string memory _nextStateName)`.
       - Simpler to maintain while avoiding name collisions.
 
 It emits events when...

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -9,7 +9,7 @@ exports.InterfaceIds = {
     IFismoOwner:    "0x7f5828d0",
     IFismoSupport:  "0x01ffc9a7",
     IFismoUpdate:   "0xf8ebd091",
-    IFismoView:     "0x26276912",
+    IFismoView:     "0x691b5451",
 
     IInvalidRandom: "0xdeadfeed",  // for negative test
 };

--- a/test/unit/FismoTest.js
+++ b/test/unit/FismoTest.js
@@ -1054,31 +1054,6 @@ describe("Fismo", function() {
 
         context("📋 IFismoView methods", async function () {
 
-            context("👉 getGuardAddress()", async function () {
-
-                beforeEach( async function () {
-
-                    [operator, operatorArgs, guards, machine] = await deployExample(deployer.address, fismo.address, LockableDoor, gasLimit);
-
-                });
-
-                it("Should return the guard address of a guarded selector", async function () {
-
-                    // The selector of the only guard function
-                    selector = nameToId("LockableDoor_Locked_Exit(address,string)");
-
-                    // Get the guard logic address
-                    expected = guards[0].contract.address;
-
-                    guardLogic = await fismo.getGuardAddress(selector);
-
-                    // Verify that the appropriate address was returned
-                    expect(guardLogic).to.equal(expected);
-
-                });
-
-            });
-
             context("👉 getLastPosition()", async function () {
 
                 beforeEach( async function () {


### PR DESCRIPTION
Passing action into transition guards enables something cool; useful, self-targeting transitions. 

State transitions don't have to lead to another state. They can target the state they're defined on. But why would you do that? 
- In an adventure game, there are two important things - moving around from room to room, and doing things while inside a room. 
- For instance, "Pick up battleaxe" could be an action that is available if there is a battleaxe in the room (guards can have their own storage and associate it with the states of the machine).
- In order for "Pick up battleaxe" to work as an action, it needs to point back to the room it is in so that no change of room happens, but the enter guard for the state can check that the previous state was the current state and if so, check the action name. if it is "Pick up battleaxe" it could remove it from the room inventory and add it to the user's inventory.

Also there is some optimization of contract size in this PR